### PR TITLE
Proper use of transaction in the sqlite migrator.

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -97,8 +97,20 @@ func (m Migrator) AlterColumn(value interface{}, name string) error {
 						columns = append(columns, fmt.Sprintf("`%v`", columnType.Name()))
 					}
 
-					createSQL = fmt.Sprintf("BEGIN TRANSACTION;"+createSQL+";INSERT INTO `%v`(%v) SELECT %v FROM `%v`;DROP TABLE `%v`;ALTER TABLE `%v` RENAME TO `%v`;COMMIT;", newTableName, strings.Join(columns, ","), strings.Join(columns, ","), stmt.Table, stmt.Table, newTableName, stmt.Table)
-					return m.DB.Exec(createSQL, m.FullDataTypeOf(field)).Error
+					return m.DB.Transaction(func(tx *gorm.DB) error {
+						queries := []string{
+							createSQL,
+							fmt.Sprintf("INSERT INTO `%v`(%v) SELECT %v FROM `%v`", newTableName, strings.Join(columns, ","), strings.Join(columns, ","), stmt.Table),
+							fmt.Sprintf("DROP TABLE `%v`", stmt.Table),
+							fmt.Sprintf("ALTER TABLE `%v` RENAME TO `%v`", newTableName, stmt.Table),
+						}
+						for _, query := range queries {
+							if err := tx.Exec(query, m.FullDataTypeOf(field)).Error; err != nil {
+								return err
+							}
+						}
+						return nil
+					})
 				} else {
 					return err
 				}


### PR DESCRIPTION
This is a proposal. If you agree I can replace all the other `BEGIN` statements of this `Migrator` in the same PR.

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

It uses the gorm transaction logic properly instead of embedding a `BEGIN` / `COMMIT` inside a big transaction

### User Case Description

While writing [a simple migration orchestration tool for Gorm](https://github.com/fclairamb/gorm-migrate) I realized that some migration commands couldn't be executed inside of a transaction with the sqlite implementation. 
As you know, this is a very common scenario for database management: You try to perform a migration possibly on multiple files and if it fails, you want to go back to the previous state.

Basycally as soon as you do something like the following code, you will be in trouble because it performs a big query with a `COMMIT` when one has already been specified earlier.
```golang
err := db.Transaction( func(tx *gorm.DB) ) {
  db.Migrator().DropColumn( &table, "column");
} )
```

