### PR TITLE
Allow custom drivers

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -14,8 +14,12 @@ import (
 	"gorm.io/gorm/schema"
 )
 
+// DriverName is the default driver name for SQLite.
+const DriverName = "sqlite3"
+
 type Dialector struct {
-	DSN string
+	DriverName string
+	DSN        string
 }
 
 func Open(dsn string) gorm.Dialector {
@@ -27,11 +31,15 @@ func (dialector Dialector) Name() string {
 }
 
 func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
+	if dialector.DriverName == "" {
+		dialector.DriverName = DriverName
+	}
+
 	// register callbacks
 	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{
 		LastInsertIDReversed: true,
 	})
-	db.ConnPool, err = sql.Open("sqlite3", dialector.DSN)
+	db.ConnPool, err = sql.Open(dialector.DriverName, dialector.DSN)
 
 	for k, v := range dialector.ClauseBuilders() {
 		db.ClauseBuilders[k] = v

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -1,0 +1,132 @@
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/mattn/go-sqlite3"
+	"gorm.io/gorm"
+)
+
+func TestDialector(t *testing.T) {
+	// This is the DSN of the in-memory SQLite database for these tests.
+	const InMemoryDSN = "file:testdatabase?mode=memory&cache=shared"
+	// This is the custom SQLite driver name.
+	const CustomDriverName = "my_custom_driver"
+
+	// Register the custom SQlite3 driver.
+	// It will have one custom function called "my_custom_function".
+	sql.Register(CustomDriverName,
+		&sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				// Define the `concat` function, since we use this elsewhere.
+				err := conn.RegisterFunc(
+					"my_custom_function",
+					func(arguments ...interface{}) (string, error) {
+						return "my-result", nil // Return a string value.
+					},
+					true,
+				)
+				return err
+			},
+		},
+	)
+
+	rows := []struct {
+		description  string
+		dialector    *Dialector
+		openSuccess  bool
+		query        string
+		querySuccess bool
+	}{
+		{
+			description: "Default driver",
+			dialector: &Dialector{
+				DSN: InMemoryDSN,
+			},
+			openSuccess:  true,
+			query:        "SELECT 1",
+			querySuccess: true,
+		},
+		{
+			description: "Explicit default driver",
+			dialector: &Dialector{
+				DriverName: DriverName,
+				DSN:        InMemoryDSN,
+			},
+			openSuccess:  true,
+			query:        "SELECT 1",
+			querySuccess: true,
+		},
+		{
+			description: "Bad driver",
+			dialector: &Dialector{
+				DriverName: "not-a-real-driver",
+				DSN:        InMemoryDSN,
+			},
+			openSuccess: false,
+		},
+		{
+			description: "Explicit default driver, custom function",
+			dialector: &Dialector{
+				DriverName: DriverName,
+				DSN:        InMemoryDSN,
+			},
+			openSuccess:  true,
+			query:        "SELECT my_custom_function()",
+			querySuccess: false,
+		},
+		{
+			description: "Custom driver",
+			dialector: &Dialector{
+				DriverName: CustomDriverName,
+				DSN:        InMemoryDSN,
+			},
+			openSuccess:  true,
+			query:        "SELECT 1",
+			querySuccess: true,
+		},
+		{
+			description: "Custom driver, custom function",
+			dialector: &Dialector{
+				DriverName: CustomDriverName,
+				DSN:        InMemoryDSN,
+			},
+			openSuccess:  true,
+			query:        "SELECT my_custom_function()",
+			querySuccess: true,
+		},
+	}
+	for rowIndex, row := range rows {
+		t.Run(fmt.Sprintf("%d/%s", rowIndex, row.description), func(t *testing.T) {
+			db, err := gorm.Open(row.dialector, &gorm.Config{})
+			if !row.openSuccess {
+				if err == nil {
+					t.Errorf("Expected Open to fail.")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Expected Open to succeed; got error: %v", err)
+			}
+			if db == nil {
+				t.Errorf("Expected db to be non-nil.")
+			}
+			if row.query != "" {
+				err = db.Exec(row.query).Error
+				if !row.querySuccess {
+					if err == nil {
+						t.Errorf("Expected query to fail.")
+					}
+					return
+				}
+
+				if err != nil {
+					t.Errorf("Expected query to succeed; got error: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Much like the `mysql` driver's `DriverName`, this allows you to specify a custom driver for SQLite.  This is important when creating custom functions, for example.

I also added unit tests to cover these changes.

### User Case Description

I frequently use SQLite in-memory databases for unit tests for my projects that use MySQL and Postgres in production.  Part of doing that is creating a custom SQLite driver that has some custom functions for parity with MySQL and Postgres (for example, `CONCAT` or `NOW`).

Because Gorm v2 does not directly specify the driver on the `Open` function anymore, this "driver" will need to be able to support it.  The `mysql` driver already does this, so this just brings this driver up to par with that one.
