### PR TITLE
take connection from dialector if available

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -20,6 +20,7 @@ const DriverName = "sqlite3"
 type Dialector struct {
 	DriverName string
 	DSN        string
+	Conn       gorm.ConnPool
 }
 
 func Open(dsn string) gorm.Dialector {
@@ -39,7 +40,15 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{
 		LastInsertIDReversed: true,
 	})
-	db.ConnPool, err = sql.Open(dialector.DriverName, dialector.DSN)
+
+	if dialector.Conn != nil {
+		db.ConnPool = dialector.Conn
+	} else {
+		db.ConnPool, err = sql.Open(dialector.DriverName, dialector.DSN)
+		if err != nil {
+			return err
+		}
+	}
 
 	for k, v := range dialector.ClauseBuilders() {
 		db.ClauseBuilders[k] = v


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Accept existing connection from dialector
To keep parity across other drivers (mysql, pg) they already do this

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
When working with elastic-apm-go it uses its own driver to open connections and hence they are traceable.
We were able to pass the apm opened connections to mysql and pg since they already have this field in Dialector

<!-- Your use case -->
