### PR TITLE
patch for https://github.com/go-gorm/sqlite/issues/7

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -101,7 +101,7 @@ func (m Migrator) DropColumn(value interface{}, name string) error {
 			name = field.DBName
 		}
 
-		reg, err := regexp.Compile("(`|'|\"| |[)" + name + "(`|'|\"| |]) .*?,")
+		reg, err := regexp.Compile("(`|'|\"| |\\[)" + name + "(`|'|\"| |\\]) .*?,")
 		if err != nil {
 			return "", nil, err
 		}


### PR DESCRIPTION
The recent fix https://github.com/go-gorm/sqlite/commit/55a60eb3a1b26a3b4e908e3a43a8ad9c21254069 for https://github.com/go-gorm/sqlite/issues/7 introduced breaking **TestMigrateColumns** in GORM.
This is due to regex was concatenated from 2 strings, one containing ```[``` , second containing ```]```.
In output regex this was considered as character class (e.g. ```[abc]```).
This fix escapes ```[``` and ```]``` with backslash, so that it's interpreted by regex engine as intended.