### PR TITLE
fix parseDDL bug with escaped quote

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -32,6 +32,7 @@ func parseDDL(strs ...string) (*ddl, error) {
 		if sections := tableRegexp.FindStringSubmatch(str); len(sections) > 0 {
 			var (
 				ddlBody      = sections[2]
+				ddlBodyRunes = []rune(ddlBody)
 				bracketLevel int
 				quote        rune
 				buf          string
@@ -39,8 +40,11 @@ func parseDDL(strs ...string) (*ddl, error) {
 
 			result.head = sections[1]
 
-			for idx, c := range []rune(ddlBody) {
-				var next rune = 0
+			for idx := 0; idx < len(ddlBodyRunes); idx++ {
+				var (
+					next rune = 0
+					c         = ddlBodyRunes[idx]
+				)
 				if idx+1 < len(ddlBody) {
 					next = []rune(ddlBody)[idx+1]
 				}

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -180,6 +180,11 @@ func TestGetColumns(t *testing.T) {
 			ddl:     "CREATE TABLE Persons (ID int NOT NULL,LastName varchar(255) NOT NULL,FirstName varchar(255),Age int,CHECK (Age>=18),CHECK (FirstName!='John'))",
 			columns: []string{"`ID`", "`LastName`", "`FirstName`", "`Age`"},
 		},
+		{
+			name:    "with_escaped_quote",
+			ddl:     "CREATE TABLE Persons (ID int NOT NULL,LastName varchar(255) NOT NULL DEFAULT \"\",FirstName varchar(255))",
+			columns: []string{"`ID`", "`LastName`", "`FirstName`"},
+		},
 	}
 
 	for _, p := range params {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

fix parseDDL bug with escaped quote, (This is probably a p0 level bug)

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

Data loss occurs when exec AutoMigrate!

reproduces:

> `gorm.io/driver/sqlite v1.3.1`
> `gorm.io/gorm v1.23.4`

1. run `AutoMigrate`, create users table
```go
package main

import (
	"gorm.io/driver/sqlite"
	"gorm.io/gorm"
	"log"
)

type User struct {
	ID int `json:"id" gorm:"primaryKey;"`

	FirstName string `json:"first_name" gorm:"size:100;not null;default:''"`
	LastName  string `json:"last_name" gorm:"size:100;not null;default:''"`
	Age       int    `json:"age" gorm:"not null;default:0"`
}

func main() {
	db, err := gorm.Open(sqlite.Open("/tmp/sqlite.db"), &gorm.Config{})
	if err != nil {
		panic("failed to connect database")
	}

	if err := db.AutoMigrate(&User{}); err != nil {
		log.Println(err)
	}
}
```
2. insert data `INSERT INTO  "users" ("first_name", "last_name", "age") VALUES ('xiao', 'ming', '18');` 
<img width="391" alt="image" src="https://user-images.githubusercontent.com/23514869/163341968-8a521681-8ee4-4f2b-8ae7-3e73fc360bee.png">

3. run `AutoMigrate` again, data loss!
<img width="351" alt="image" src="https://user-images.githubusercontent.com/23514869/163341779-c44f265b-3ab8-424e-83ab-549bd4763f43.png">


