### PR TITLE
fix: parseDDL index out of range

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -37,16 +37,17 @@ func parseDDL(strs ...string) (*ddl, error) {
 				quote        rune
 				buf          string
 			)
+			ddlBodyRunesLen := len(ddlBodyRunes)
 
 			result.head = sections[1]
 
-			for idx := 0; idx < len(ddlBodyRunes); idx++ {
+			for idx := 0; idx < ddlBodyRunesLen; idx++ {
 				var (
 					next rune = 0
 					c         = ddlBodyRunes[idx]
 				)
-				if idx+1 < len(ddlBody) {
-					next = []rune(ddlBody)[idx+1]
+				if idx+1 < ddlBodyRunesLen {
+					next = ddlBodyRunes[idx+1]
 				}
 
 				if sc := string(c); separatorRegexp.MatchString(sc) {

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -36,6 +36,12 @@ func TestParseDDL(t *testing.T) {
 		},
 		},
 		{"no brackets", []string{"create table test"}, 0, nil},
+		{"with_special_characters", []string{
+			"CREATE TABLE `test` (`text` varchar(10) DEFAULT \"测试，\")",
+		}, 1, []migrator.ColumnType{
+			{NameValue: sql.NullString{String: "text", Valid: true}, DataTypeValue: sql.NullString{String: "varchar(10)", Valid: true}, ColumnTypeValue: sql.NullString{String: "varchar(10)", Valid: true}, DefaultValueValue: sql.NullString{String: "测试，", Valid: true}, NullableValue: sql.NullBool{Valid: true}, UniqueValue: sql.NullBool{Valid: true}, PrimaryKeyValue: sql.NullBool{Valid: true}},
+		},
+		},
 	}
 
 	for _, p := range params {


### PR DESCRIPTION

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
parseDDL index out of range when characters take up more than one byte
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
Panic(index out of range) when sql like: ```CREATE TABLE `test` (`text` varchar(10) DEFAULT "测试，")```
