### PR TITLE
ignore generated columns when [recreateTable]

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -229,3 +229,25 @@ func (d *ddl) getColumns() []string {
 	}
 	return res
 }
+
+func (d *ddl) getSafeColumns() []string {
+	res := []string{}
+
+	for _, f := range d.fields {
+		fUpper := strings.ToUpper(f)
+		if strings.HasPrefix(fUpper, "PRIMARY KEY") ||
+			strings.HasPrefix(fUpper, "CHECK") ||
+			strings.HasPrefix(fUpper, "CONSTRAINT") ||
+			strings.Contains(fUpper, "GENERATED ALWAYS AS") {
+			continue
+		}
+
+		reg := regexp.MustCompile("^[\"`']?([\\w\\d]+)[\"`']?")
+		match := reg.FindStringSubmatch(f)
+
+		if match != nil {
+			res = append(res, "`"+match[1]+"`")
+		}
+	}
+	return res
+}

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -216,27 +216,6 @@ func (d *ddl) getColumns() []string {
 		fUpper := strings.ToUpper(f)
 		if strings.HasPrefix(fUpper, "PRIMARY KEY") ||
 			strings.HasPrefix(fUpper, "CHECK") ||
-			strings.HasPrefix(fUpper, "CONSTRAINT") {
-			continue
-		}
-
-		reg := regexp.MustCompile("^[\"`']?([\\w\\d]+)[\"`']?")
-		match := reg.FindStringSubmatch(f)
-
-		if match != nil {
-			res = append(res, "`"+match[1]+"`")
-		}
-	}
-	return res
-}
-
-func (d *ddl) getSafeColumns() []string {
-	res := []string{}
-
-	for _, f := range d.fields {
-		fUpper := strings.ToUpper(f)
-		if strings.HasPrefix(fUpper, "PRIMARY KEY") ||
-			strings.HasPrefix(fUpper, "CHECK") ||
 			strings.HasPrefix(fUpper, "CONSTRAINT") ||
 			strings.Contains(fUpper, "GENERATED ALWAYS AS") {
 			continue

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -37,9 +37,9 @@ func TestParseDDL(t *testing.T) {
 		},
 		{"no brackets", []string{"create table test"}, 0, nil},
 		{"with_special_characters", []string{
-			"CREATE TABLE `test` (`text` varchar(10) DEFAULT \"ÊµãËØïÔºå\")",
+			"CREATE TABLE `test` (`text` varchar(10) DEFAULT \"测试\")",
 		}, 1, []migrator.ColumnType{
-			{NameValue: sql.NullString{String: "text", Valid: true}, DataTypeValue: sql.NullString{String: "varchar", Valid: true}, LengthValue: sql.NullInt64{Int64: 10, Valid: true}, ColumnTypeValue: sql.NullString{String: "varchar(10)", Valid: true}, DefaultValueValue: sql.NullString{String: "ÊµãËØïÔºå", Valid: true}, NullableValue: sql.NullBool{Valid: true}, UniqueValue: sql.NullBool{Valid: true}, PrimaryKeyValue: sql.NullBool{Valid: true}},
+			{NameValue: sql.NullString{String: "text", Valid: true}, DataTypeValue: sql.NullString{String: "varchar", Valid: true}, LengthValue: sql.NullInt64{Int64: 10, Valid: true}, ColumnTypeValue: sql.NullString{String: "varchar(10)", Valid: true}, DefaultValueValue: sql.NullString{String: "测试", Valid: true}, NullableValue: sql.NullBool{Valid: true}, UniqueValue: sql.NullBool{Valid: true}, PrimaryKeyValue: sql.NullBool{Valid: true}},
 		},
 		},
 		{

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -37,9 +37,9 @@ func TestParseDDL(t *testing.T) {
 		},
 		{"no brackets", []string{"create table test"}, 0, nil},
 		{"with_special_characters", []string{
-			"CREATE TABLE `test` (`text` varchar(10) DEFAULT \"测试\")",
+			"CREATE TABLE `test` (`text` varchar(10) DEFAULT \"测试, \")",
 		}, 1, []migrator.ColumnType{
-			{NameValue: sql.NullString{String: "text", Valid: true}, DataTypeValue: sql.NullString{String: "varchar", Valid: true}, LengthValue: sql.NullInt64{Int64: 10, Valid: true}, ColumnTypeValue: sql.NullString{String: "varchar(10)", Valid: true}, DefaultValueValue: sql.NullString{String: "测试", Valid: true}, NullableValue: sql.NullBool{Valid: true}, UniqueValue: sql.NullBool{Valid: true}, PrimaryKeyValue: sql.NullBool{Valid: true}},
+			{NameValue: sql.NullString{String: "text", Valid: true}, DataTypeValue: sql.NullString{String: "varchar", Valid: true}, LengthValue: sql.NullInt64{Int64: 10, Valid: true}, ColumnTypeValue: sql.NullString{String: "varchar(10)", Valid: true}, DefaultValueValue: sql.NullString{String: "测试, ", Valid: true}, NullableValue: sql.NullBool{Valid: true}, UniqueValue: sql.NullBool{Valid: true}, PrimaryKeyValue: sql.NullBool{Valid: true}},
 		},
 		},
 		{

--- a/migrator.go
+++ b/migrator.go
@@ -400,7 +400,7 @@ func (m Migrator) recreateTable(value interface{}, tablePtr *string,
 		if err != nil {
 			return err
 		}
-		columns := createDDL.getSafeColumns()
+		columns := createDDL.getColumns()
 
 		return m.DB.Transaction(func(tx *gorm.DB) error {
 			if err := tx.Exec(createSQL, sqlArgs...).Error; err != nil {

--- a/migrator.go
+++ b/migrator.go
@@ -400,7 +400,7 @@ func (m Migrator) recreateTable(value interface{}, tablePtr *string,
 		if err != nil {
 			return err
 		}
-		columns := createDDL.getColumns()
+		columns := createDDL.getSafeColumns()
 
 		return m.DB.Transaction(func(tx *gorm.DB) error {
 			if err := tx.Exec(createSQL, sqlArgs...).Error; err != nil {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
This pull request fix this issue:
https://github.com/go-gorm/gorm/issues/5590
```
cannot INSERT into generated column
```
I just created another method for `ddl` called `getSafeColumns`. It did the exact work of `getColumns` except it ignore the GENERATED COLUMNS.

### User Case Description
This is important for `recreateTable` of the Migrator.
```go
// Old
columns := createDDL.getColumns()
// New
columns := createDDL.getSafeColumns()
```
