### PR TITLE
fixed sqlite sql field not null bug

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -117,16 +117,13 @@ func parseDDL(strs ...string) (*ddl, error) {
 						ColumnTypeValue:   sql.NullString{String: matches[2], Valid: true},
 						PrimaryKeyValue:   sql.NullBool{Valid: true},
 						UniqueValue:       sql.NullBool{Valid: true},
-						
-						:     sql.NullBool{Valid: true},
+						NullableValue:     sql.NullBool{Bool:true, Valid: true},
 						DefaultValueValue: sql.NullString{Valid: false},
 					}
 
 					matchUpper := strings.ToUpper(matches[3])
 					if strings.Contains(matchUpper, " NOT NULL") {
 						columnType.NullableValue = sql.NullBool{Bool: false, Valid: true}
-					} else {
-						columnType.NullableValue = sql.NullBool{Bool: true, Valid: true}
 					}
 					if strings.Contains(matchUpper, " UNIQUE") {
 						columnType.UniqueValue = sql.NullBool{Bool: true, Valid: true}

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -117,14 +117,15 @@ func parseDDL(strs ...string) (*ddl, error) {
 						ColumnTypeValue:   sql.NullString{String: matches[2], Valid: true},
 						PrimaryKeyValue:   sql.NullBool{Valid: true},
 						UniqueValue:       sql.NullBool{Valid: true},
-						NullableValue:     sql.NullBool{Valid: true},
+						
+						:     sql.NullBool{Valid: true},
 						DefaultValueValue: sql.NullString{Valid: false},
 					}
 
 					matchUpper := strings.ToUpper(matches[3])
 					if strings.Contains(matchUpper, " NOT NULL") {
 						columnType.NullableValue = sql.NullBool{Bool: false, Valid: true}
-					} else if strings.Contains(matchUpper, " NULL") {
+					} else {
 						columnType.NullableValue = sql.NullBool{Bool: true, Valid: true}
 					}
 					if strings.Contains(matchUpper, " UNIQUE") {


### PR DESCRIPTION

- [] Do only one thing
- [x] Non breaking API changes
- [] Tested

### What did this pull request do?

<!--
CREATE TABLE "accounts" (
 ...
  "deleted_at" datetime,
 ...
)

gen result

type Account struct {
        ...
	DeletedAt gorm.DeletedAt `gorm:"column:deleted_at;not null" json:"deleted_at"`
        ...
}

Results don't match
-->


