### PR TITLE
fix: dependency issue with go-sqlite3 package

### DIFF
--- a/error_translator.go
+++ b/error_translator.go
@@ -16,6 +16,8 @@ type ErrMessage struct {
 	SystemErrno  int `json:"SystemErrno"`
 }
 
+// Translate it will translate the error to native gorm errors.
+// We are not using go-sqlite3 error type intentionally here because it will need the CGO_ENABLED=1 and cross-C-compiler.
 func (dialector Dialector) Translate(err error) error {
 	parsedErr, marshalErr := json.Marshal(err)
 	if marshalErr != nil {

--- a/error_translator.go
+++ b/error_translator.go
@@ -1,21 +1,35 @@
 package sqlite
 
 import (
-	"github.com/mattn/go-sqlite3"
+	"encoding/json"
 
 	"gorm.io/gorm"
 )
 
-var errCodes = map[string]sqlite3.ErrNoExtended{
+var errCodes = map[string]int{
 	"uniqueConstraint": 2067,
 }
 
+type ErrMessage struct {
+	Code         int `json:"Code"`
+	ExtendedCode int `json:"ExtendedCode"`
+	SystemErrno  int `json:"SystemErrno"`
+}
+
 func (dialector Dialector) Translate(err error) error {
-	if sqliteErr, ok := err.(*sqlite3.Error); ok {
-		if sqliteErr.ExtendedCode == errCodes["uniqueConstraint"] {
-			return gorm.ErrDuplicatedKey
-		}
+	parsedErr, marshalErr := json.Marshal(err)
+	if marshalErr != nil {
+		return err
 	}
 
+	var errMsg ErrMessage
+	unmarshalErr := json.Unmarshal(parsedErr, &errMsg)
+	if unmarshalErr != nil {
+		return err
+	}
+
+	if errMsg.ExtendedCode == errCodes["uniqueConstraint"] {
+		return gorm.ErrDuplicatedKey
+	}
 	return err
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
The new error translation functionality was depending on go-sqlite3 package types and since the go-sqlite3 is a cgo package it needs the CGO_ENABLED=1 flag required plus it will require new compilers like cross-C-compiler to be installed on the machine.

In this PR I reimplement the error translation and do not depend on go-sqlite3 package at all.

