### PR TITLE
fix: RenameIndex should drop old index

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -322,6 +322,9 @@ func (m Migrator) RenameIndex(value interface{}, oldName, newName string) error 
 		var sql string
 		m.DB.Raw("SELECT sql FROM sqlite_master WHERE type = ? AND tbl_name = ? AND name = ?", "index", stmt.Table, oldName).Row().Scan(&sql)
 		if sql != "" {
+			if err := m.DropIndex(value, oldName); err != nil {
+				return err
+			}
 			return m.DB.Exec(strings.Replace(sql, oldName, newName, 1)).Error
 		}
 		return fmt.Errorf("failed to find index with name %v", oldName)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [ ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
RenameIndex should drop old index.
It blocked https://github.com/go-gorm/gorm/pull/6303

### User Case Description

<!-- Your use case -->
