### PR TITLE
fix: translate SQLITE_CONSTRAINT_PRIMARYKEY to ErrDuplicatedKey

### DIFF
--- a/error_translator.go
+++ b/error_translator.go
@@ -7,6 +7,7 @@ import (
 )
 
 var errCodes = map[int]error{
+	1555: gorm.ErrDuplicatedKey,
 	2067: gorm.ErrDuplicatedKey,
 	768:  gorm.ErrForeignKeyViolated,
 }


### PR DESCRIPTION

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Translate the SQLITE_CONSTRAINT_PRIMARYKEY error code to ErrDuplicatedKey as well for consistency.

### User Case Description

We refactored our code to take advantage of ErrDuplicatedKey, but the tests fail because ErrDuplicatedKey only gets returned for non primary key fields (and it should IMO):

https://github.com/italia/developers-italia-api/pull/197
https://github.com/italia/developers-italia-api/actions/runs/5143820348/jobs/9259314436?pr=197

Also, should this go in https://github.com/go-gorm/postgres and https://github.com/go-gorm/mysql as well?

