### PR TITLE
Fix columnType.Unique() returns true for non-unique index DDL.

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -162,7 +162,7 @@ func parseDDL(strs ...string) (*ddl, error) {
 			for _, column := range getAllColumns(matches[1]) {
 				for idx, c := range result.columns {
 					if c.NameValue.String == column {
-						c.UniqueValue = sql.NullBool{Bool: true, Valid: true}
+						c.UniqueValue = sql.NullBool{Bool: strings.ToUpper(strings.Fields(str)[1]) == "UNIQUE", Valid: true}
 						result.columns[idx] = c
 					}
 				}

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -79,6 +79,24 @@ func TestParseDDL(t *testing.T) {
 				},
 			},
 		},
+		{
+			"non-unique index",
+			[]string{
+				"CREATE TABLE `test-c` (`field` integer NOT NULL)",
+				"CREATE INDEX `idx_uq` ON `test-b`(`field`) WHERE field = 0",
+			},
+			1,
+			[]migrator.ColumnType{
+				{
+					NameValue:       sql.NullString{String: "field", Valid: true},
+					DataTypeValue:   sql.NullString{String: "integer", Valid: true},
+					ColumnTypeValue: sql.NullString{String: "integer", Valid: true},
+					PrimaryKeyValue: sql.NullBool{Bool: false, Valid: true},
+					UniqueValue:     sql.NullBool{Bool: false, Valid: true},
+					NullableValue:   sql.NullBool{Bool: false, Valid: true},
+				},
+			},
+		},
 	}
 
 	for _, p := range params {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

Fixes an issue where the migrator determines that a column is unique (true) when referenced in an index DDL without further determining whether the index is unique.  As a result, a model with a non-unique index tag is always be deemed different than the DDL which always triggers a table migration.  The fix is to determine the column uniqueness based on whether the referencing index DDL is `CREATE UNIQUE INDEX ...` and not `CREATE INDEX`.

<!--
provide a general description of the code changes in your pull request
-->

Set the `ColumnType.UniqueValue` based on the column being referenced in a UNIQUE index (not just any index).

### User Case Description

Common use case of to add a non unique index on a foreign key to support cascade delete.  As a result, the auto-migrate detecting a difference and ALWAYS is migrating the table.

<!-- Your use case -->

The use case: model defined as Person with `1-*` relation to Parent (so the index cannot be unique).
```
type Person struct {
    ParentID uint `gorm:"index;not-null"`
}
```

```
CREATE INDEX idx_person ON person (parentid)
```
Results in: `ColumnType.UniqueValue` = `true`.