### PR TITLE
fix: ErrForeignKeyViolated error constant

### DIFF
--- a/error_translator.go
+++ b/error_translator.go
@@ -6,6 +6,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// The error codes to map sqlite errors to gorm errors, here is a reference about error codes for sqlite https://www.sqlite.org/rescode.html.
 var errCodes = map[int]error{
 	2067: gorm.ErrDuplicatedKey,
 	787:  gorm.ErrForeignKeyViolated,

--- a/error_translator.go
+++ b/error_translator.go
@@ -8,7 +8,7 @@ import (
 
 var errCodes = map[int]error{
 	2067: gorm.ErrDuplicatedKey,
-	768:  gorm.ErrForeignKeyViolated,
+	787:  gorm.ErrForeignKeyViolated,
 }
 
 type ErrMessage struct {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

ErrForeignKeyViolated error was not set up correctly with SQLITE_CONSTRAINT_FOREIGNKEY constant. Within this PR it is mapped to the right SQLITE_CONSTRAINT_FOREIGNKEY. https://www.sqlite.org/rescode.html#constraint_foreignkey