### PR TITLE
fix: double quoted string literals in migrator

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -339,7 +339,7 @@ func (m Migrator) GetIndexes(value interface{}) ([]gorm.Index, error) {
 	indexes := make([]gorm.Index, 0)
 	err := m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		rst := make([]*Index, 0)
-		if err := m.DB.Debug().Raw(fmt.Sprintf("PRAGMA index_list(%q)", stmt.Table)).Scan(&rst).Error; err != nil {
+		if err := m.DB.Debug().Raw("SELECT * FROM PRAGMA_index_list(?)", stmt.Table).Scan(&rst).Error; err != nil { // alias `PRAGMA index_list(?)`
 			return err
 		}
 		for _, index := range rst {
@@ -347,7 +347,7 @@ func (m Migrator) GetIndexes(value interface{}) ([]gorm.Index, error) {
 				continue
 			}
 			var columns []string
-			if err := m.DB.Raw(fmt.Sprintf("SELECT name from PRAGMA_index_info(%q)", index.Name)).Scan(&columns).Error; err != nil { // alias `PRAGMA index_info(?)`
+			if err := m.DB.Raw("SELECT name FROM PRAGMA_index_info(?)", index.Name).Scan(&columns).Error; err != nil { // alias `PRAGMA index_info(?)`
 				return err
 			}
 			indexes = append(indexes, &migrator.Index{


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Using `%q` is not appropriate to quote a string literal in RAW SQL. Double-quoted strings are considered a [misfeature](https://www.sqlite.org/quirks.html#dblquote) of SQLite, and advised to be disabled at [compile time](https://www.sqlite.org/compile.html#dqs). Also, `%q` produces the _wrong_ quoting: `Hi "GORM"!` is quoted as `"Hi \"GORM\"!"` not `"Hi ""GORM""!"`, as SQLite would expect.

Current head fails GORM `TestMigrateWithUniqueIndexAndUnique` if SQLite is configured with `SQLITE_DQS=0`.

### User Case Description

