### PR TITLE
Added Config for custom driver (specifically libSQL)

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -43,11 +43,12 @@ func (dialector Dialector) Name() string {
 }
 
 func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
+	if dialector.DriverName == "" {
+		dialector.DriverName = DriverName
+	}
 
 	if dialector.Conn != nil {
 		db.ConnPool = dialector.Conn
-	} else if dialector.DriverName != "" {
-		db.ConnPool, err = sql.Open(dialector.DriverName, dialector.DSN)
 	} else {
 		conn, err := sql.Open(dialector.DriverName, dialector.DSN)
 		if err != nil {

--- a/sqlite.go
+++ b/sqlite.go
@@ -24,8 +24,18 @@ type Dialector struct {
 	Conn       gorm.ConnPool
 }
 
+type Config struct {
+	DriverName string
+	DSN        string
+	Conn       gorm.ConnPool
+}
+
 func Open(dsn string) gorm.Dialector {
 	return &Dialector{DSN: dsn}
+}
+
+func New(config Config) gorm.Dialector {
+	return &Dialector{DSN: config.DSN, DriverName: config.DriverName, Conn: config.Conn}
 }
 
 func (dialector Dialector) Name() string {
@@ -33,12 +43,11 @@ func (dialector Dialector) Name() string {
 }
 
 func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
-	if dialector.DriverName == "" {
-		dialector.DriverName = DriverName
-	}
 
 	if dialector.Conn != nil {
 		db.ConnPool = dialector.Conn
+	} else if dialector.DriverName != "" {
+		db.ConnPool, err = sql.Open(dialector.DriverName, dialector.DSN)
 	} else {
 		conn, err := sql.Open(dialector.DriverName, dialector.DSN)
 		if err != nil {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

It adds a Config struct that can be used the same way the Postgres version can be. This allows a user to add their own driver instead of using the pre-defined one.

### User Case Description
To use this with libSQL or Turso compatible SQLite
