### PR TITLE
fix(Migrator): disable foreign keys during DropColumn

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -155,13 +155,15 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 }
 
 func (m Migrator) DropColumn(value interface{}, name string) error {
-	return m.recreateTable(value, nil, func(ddl *ddl, stmt *gorm.Statement) (*ddl, []interface{}, error) {
-		if field := stmt.Schema.LookUpField(name); field != nil {
-			name = field.DBName
-		}
+	return m.RunWithoutForeignKey(func() error {
+		return m.recreateTable(value, nil, func(ddl *ddl, stmt *gorm.Statement) (*ddl, []interface{}, error) {
+			if field := stmt.Schema.LookUpField(name); field != nil {
+				name = field.DBName
+			}
 
-		ddl.removeColumn(name)
-		return ddl, nil, nil
+			ddl.removeColumn(name)
+			return ddl, nil, nil
+		})
 	})
 }
 


### PR DESCRIPTION
Closes #119

## Problem

DropColumn fails when foreign keys are enabled because it calls recreateTable, which performs DROP TABLE + INSERT INTO + ALTER TABLE RENAME. SQLite enforces FK constraints on the INSERT INTO step, causing the operation to fail with constraint violation errors.

## Solution

Wrap DropColumn in RunWithoutForeignKey, following the exact same pattern already used by AlterColumn and DropTable in this file.

## Before

```go
func (m Migrator) DropColumn(value interface{}, name string) error {
    return m.recreateTable(value, nil, func(...) { ... })
}
```

## After

```go
func (m Migrator) DropColumn(value interface{}, name string) error {
    return m.RunWithoutForeignKey(func() error {
        return m.recreateTable(value, nil, func(...) { ... })
    })
}
```