### PR TITLE
fix(Migrator): make HasColumn match the exact column via pragma_table_info

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -66,8 +66,8 @@ func (m Migrator) HasColumn(value interface{}, name string) bool {
 
 		if name != "" {
 			m.DB.Raw(
-				"SELECT count(*) FROM sqlite_master WHERE type = ? AND tbl_name = ? AND (sql LIKE ? OR sql LIKE ? OR sql LIKE ? OR sql LIKE ? OR sql LIKE ?)",
-				"table", stmt.Table, `%"`+name+`" %`, `%`+name+` %`, "%`"+name+"`%", "%["+name+"]%", "%\t"+name+"\t%",
+				"SELECT count(*) FROM pragma_table_info(?) WHERE name = ? COLLATE NOCASE",
+				stmt.Table, name,
 			).Row().Scan(&count)
 		}
 		return nil

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -15,6 +15,13 @@ func TestHasColumnNoFalsePositive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gorm.Open: %v", err)
 	}
+	// close the pool so the shared in-memory database is torn down and
+	// repeated runs (go test -count=N) start from a clean state
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
 
 	// name is a substring of first_name in an unquoted DDL
 	if err := db.Exec("CREATE TABLE plaincols (id integer, first_name text)").Error; err != nil {

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -1,0 +1,40 @@
+package sqlite
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+// HasColumn used to match the column name as a LIKE substring against the
+// table DDL, which reported columns as present when the name merely appeared
+// inside another column name or a string default value. AutoMigrate then
+// skipped AddColumn and later queries failed with "no such column".
+func TestHasColumnNoFalsePositive(t *testing.T) {
+	db, err := gorm.Open(Open("file:hascolumn_exact?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+
+	// name is a substring of first_name in an unquoted DDL
+	if err := db.Exec("CREATE TABLE plaincols (id integer, first_name text)").Error; err != nil {
+		t.Fatal(err)
+	}
+	if db.Migrator().HasColumn("plaincols", "name") {
+		t.Error(`HasColumn("plaincols", "name") = true, want false (only first_name exists)`)
+	}
+	if !db.Migrator().HasColumn("plaincols", "first_name") {
+		t.Error(`HasColumn("plaincols", "first_name") = false, want true`)
+	}
+
+	// name appears inside a string default value
+	if err := db.Exec("CREATE TABLE `defv` (`id` integer, `cfg` text DEFAULT 'name value')").Error; err != nil {
+		t.Fatal(err)
+	}
+	if db.Migrator().HasColumn("defv", "name") {
+		t.Error(`HasColumn("defv", "name") = true, want false (name only appears in a default value)`)
+	}
+	if !db.Migrator().HasColumn("defv", "cfg") {
+		t.Error(`HasColumn("defv", "cfg") = false, want true`)
+	}
+}


### PR DESCRIPTION
### What this PR does

`HasColumn` matches the column name as a LIKE substring against the raw table DDL, which reports columns as present when their name merely appears somewhere in the DDL text:

```sql
CREATE TABLE plaincols (id integer, first_name text);
-- HasColumn("plaincols", "name") returns true: "first_name text" contains "name "

CREATE TABLE `defv` (`id` integer, `cfg` text DEFAULT 'name value');
-- HasColumn("defv", "name") returns true: the default value contains "name "
```

When this false positive hits during `AutoMigrate`, the driver skips `AddColumn` for a genuinely missing column and later queries fail with `no such column`.

### The fix

Query `pragma_table_info` instead, which returns the actual columns of the table:

```sql
SELECT count(*) FROM pragma_table_info(?) WHERE name = ? COLLATE NOCASE
```

`COLLATE NOCASE` keeps the comparison case-insensitive, as the LIKE patterns were. This matches how `HasTable` and `GetIndexes` already query metadata instead of searching SQL text.

### Tests

`TestHasColumnNoFalsePositive` covers both false-positive scenarios above plus the positive cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)