### PR TITLE
fix(Migrator): preserve indexes, triggers, table options and views across table rebuilds

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -16,7 +16,7 @@ var (
 	sqliteColumnQuote  = "`"
 	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?:CONSTRAINT [%v]?[\w-]+[%v]? )?UNIQUE (.*)$`, sqliteSeparator, sqliteSeparator))
 	indexRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)CREATE(?: UNIQUE)? INDEX [%v]?[\w\d-]+[%v]?(?s:.*?)ON (.*)$`, sqliteSeparator, sqliteSeparator))
-	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v]?[\w\d-]+[%v]?)(?:\s*\((.*)\))?`, sqliteSeparator, sqliteSeparator))
+	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v]?[\w\d-]+[%v]?)(?:\s*\((.*)\))?(.*)$`, sqliteSeparator, sqliteSeparator))
 	checkRegexp        = regexp.MustCompile(`^(?i)CHECK[\s]*\(`)
 	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+%[1]s[\w\d_]+%[1]s[\s]+`, sqliteColumnQuote))
 	separatorRegexp    = regexp.MustCompile(fmt.Sprintf("[%v]", sqliteSeparator))
@@ -28,6 +28,7 @@ var (
 type ddl struct {
 	head    string
 	fields  []string
+	suffix  string // table options after the column list, e.g. WITHOUT ROWID, STRICT
 	columns []migrator.ColumnType
 }
 
@@ -45,6 +46,7 @@ func parseDDL(strs ...string) (*ddl, error) {
 			ddlBodyRunesLen := len(ddlBodyRunes)
 
 			result.head = sections[1]
+			result.suffix = sections[3]
 
 			for idx := 0; idx < ddlBodyRunesLen; idx++ {
 				var (
@@ -193,10 +195,10 @@ func (d *ddl) clone() *ddl {
 
 func (d *ddl) compile() string {
 	if len(d.fields) == 0 {
-		return d.head
+		return d.head + d.suffix
 	}
 
-	return fmt.Sprintf("%s (%s)", d.head, strings.Join(d.fields, ","))
+	return fmt.Sprintf("%s (%s)%s", d.head, strings.Join(d.fields, ","), d.suffix)
 }
 
 func (d *ddl) renameTable(dst, src string) error {

--- a/migrator.go
+++ b/migrator.go
@@ -451,9 +451,15 @@ func (m Migrator) recreateTable(
 			}
 
 			// recreate the saved indexes and triggers; ones referencing a
-			// column that no longer exists cannot apply anymore and are skipped
+			// column that no longer exists cannot apply anymore and are
+			// skipped, any other failure aborts the migration
 			for _, aux := range auxDDLs {
-				_ = tx.Exec(aux).Error
+				if err := tx.Exec(aux).Error; err != nil {
+					if strings.Contains(err.Error(), "no such column") {
+						continue
+					}
+					return err
+				}
 			}
 			return nil
 		})

--- a/migrator.go
+++ b/migrator.go
@@ -411,6 +411,16 @@ func (m Migrator) recreateTable(
 		columns := createDDL.getColumns()
 		createSQL := createDDL.compile()
 
+		// indexes and triggers are dropped together with the old table; save
+		// their DDL so they can be recreated on the rebuilt table.
+		var auxDDLs []string
+		if err := m.DB.Raw(
+			"SELECT sql FROM sqlite_master WHERE tbl_name = ? AND type IN (?, ?) AND sql IS NOT NULL",
+			table, "index", "trigger",
+		).Scan(&auxDDLs).Error; err != nil {
+			return err
+		}
+
 		return m.DB.Transaction(func(tx *gorm.DB) error {
 			if err := tx.Exec(createSQL, sqlArgs...).Error; err != nil {
 				return err
@@ -419,12 +429,31 @@ func (m Migrator) recreateTable(
 			queries := []string{
 				fmt.Sprintf("INSERT INTO `%v`(%v) SELECT %v FROM `%v`", newTableName, strings.Join(columns, ","), strings.Join(columns, ","), table),
 				fmt.Sprintf("DROP TABLE `%v`", table),
-				fmt.Sprintf("ALTER TABLE `%v` RENAME TO `%v`", newTableName, table),
 			}
 			for _, query := range queries {
 				if err := tx.Exec(query).Error; err != nil {
 					return err
 				}
+			}
+
+			// legacy_alter_table keeps RENAME from re-resolving views that
+			// reference the table; they point at the original name and become
+			// valid again right after the rename.
+			if err := tx.Exec("PRAGMA legacy_alter_table = ON").Error; err != nil {
+				return err
+			}
+			renameErr := tx.Exec(fmt.Sprintf("ALTER TABLE `%v` RENAME TO `%v`", newTableName, table)).Error
+			if err := tx.Exec("PRAGMA legacy_alter_table = OFF").Error; renameErr == nil {
+				renameErr = err
+			}
+			if renameErr != nil {
+				return renameErr
+			}
+
+			// recreate the saved indexes and triggers; ones referencing a
+			// column that no longer exists cannot apply anymore and are skipped
+			for _, aux := range auxDDLs {
+				_ = tx.Exec(aux).Error
 			}
 			return nil
 		})

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"strings"
 	"testing"
 
 	"gorm.io/gorm"
@@ -44,4 +45,123 @@ func TestHasColumnNoFalsePositive(t *testing.T) {
 	if !db.Migrator().HasColumn("defv", "cfg") {
 		t.Error(`HasColumn("defv", "cfg") = false, want true`)
 	}
+}
+
+type RebuildIdxTable struct {
+	ID int
+	A  string
+	B  string
+}
+
+func (RebuildIdxTable) TableName() string { return "rebuild_idx_table" }
+
+// recreateTable drops the old table together with its indexes and triggers;
+// they must be recreated on the rebuilt table. Indexes on a dropped column
+// are the exception: they can no longer apply.
+func TestRecreateTablePreservesIndexesAndTriggers(t *testing.T) {
+	db := openRecreateTestDB(t, "recreate_idx")
+	stmts := []string{
+		"CREATE TABLE `rebuild_idx_table` (`id` integer, `a` text, `b` text)",
+		"CREATE INDEX `idx_keep` ON `rebuild_idx_table`(`a`)",
+		"CREATE INDEX `idx_gone` ON `rebuild_idx_table`(`b`)",
+		"CREATE TABLE `rebuild_audit` (`msg` text)",
+		"CREATE TRIGGER `trg_keep` AFTER INSERT ON `rebuild_idx_table` BEGIN INSERT INTO `rebuild_audit`(`msg`) VALUES ('x'); END",
+	}
+	for _, s := range stmts {
+		if err := db.Exec(s).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := db.Migrator().DropColumn(&RebuildIdxTable{}, "b"); err != nil {
+		t.Fatalf("DropColumn: %v", err)
+	}
+
+	var names []string
+	db.Raw("SELECT name FROM sqlite_master WHERE tbl_name = 'rebuild_idx_table' AND type IN ('index','trigger')").Scan(&names)
+	got := strings.Join(names, ",")
+	if !strings.Contains(got, "idx_keep") {
+		t.Errorf("index idx_keep lost after DropColumn, remaining: %v", names)
+	}
+	if !strings.Contains(got, "trg_keep") {
+		t.Errorf("trigger trg_keep lost after DropColumn, remaining: %v", names)
+	}
+	if strings.Contains(got, "idx_gone") {
+		t.Errorf("index idx_gone references the dropped column and must not survive, remaining: %v", names)
+	}
+
+	// the trigger still works on the rebuilt table
+	if err := db.Exec("INSERT INTO `rebuild_idx_table`(`id`,`a`) VALUES (1,'v')").Error; err != nil {
+		t.Fatal(err)
+	}
+	var auditCount int
+	db.Raw("SELECT count(*) FROM rebuild_audit").Scan(&auditCount)
+	if auditCount != 1 {
+		t.Errorf("trigger did not fire after rebuild, audit rows = %d", auditCount)
+	}
+}
+
+type RebuildOptsTable struct {
+	ID string `gorm:"primaryKey"`
+	A  string
+	B  string
+}
+
+func (RebuildOptsTable) TableName() string { return "rebuild_opts_table" }
+
+// Table options after the column list (WITHOUT ROWID, STRICT) must survive a
+// table rebuild instead of silently turning the table into a plain rowid one.
+func TestRecreateTablePreservesTableOptions(t *testing.T) {
+	db := openRecreateTestDB(t, "recreate_opts")
+	if err := db.Exec("CREATE TABLE `rebuild_opts_table` (`id` text PRIMARY KEY, `a` text, `b` text) WITHOUT ROWID").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Migrator().DropColumn(&RebuildOptsTable{}, "b"); err != nil {
+		t.Fatalf("DropColumn: %v", err)
+	}
+
+	var ddl string
+	db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='rebuild_opts_table'").Scan(&ddl)
+	if !strings.Contains(ddl, "WITHOUT ROWID") {
+		t.Errorf("WITHOUT ROWID lost after rebuild: %s", ddl)
+	}
+}
+
+type RebuildViewedTable struct {
+	ID int
+	A  string
+	B  string
+}
+
+func (RebuildViewedTable) TableName() string { return "rebuild_viewed" }
+
+// Rebuilding a table that a view references used to fail with "error in view
+// ...: no such table" because the RENAME step re-resolves the view while the
+// original table name doesn't exist yet (issue #225).
+func TestRecreateTableWithView(t *testing.T) {
+	db := openRecreateTestDB(t, "recreate_view")
+	if err := db.Exec("CREATE TABLE `rebuild_viewed` (`id` integer, `a` text, `b` text)").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec("CREATE VIEW `rebuild_viewed_v` AS SELECT `a` FROM `rebuild_viewed`").Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Migrator().DropColumn(&RebuildViewedTable{}, "b"); err != nil {
+		t.Fatalf("DropColumn with a referencing view: %v", err)
+	}
+
+	var n int
+	if err := db.Raw("SELECT count(*) FROM `rebuild_viewed_v`").Scan(&n).Error; err != nil {
+		t.Errorf("view is broken after rebuild: %v", err)
+	}
+}
+
+func openRecreateTestDB(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(Open("file:"+name+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	return db
 }

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -78,7 +78,9 @@ func TestRecreateTablePreservesIndexesAndTriggers(t *testing.T) {
 	}
 
 	var names []string
-	db.Raw("SELECT name FROM sqlite_master WHERE tbl_name = 'rebuild_idx_table' AND type IN ('index','trigger')").Scan(&names)
+	if err := db.Raw("SELECT name FROM sqlite_master WHERE tbl_name = 'rebuild_idx_table' AND type IN ('index','trigger')").Scan(&names).Error; err != nil {
+		t.Fatalf("querying sqlite_master: %v", err)
+	}
 	got := strings.Join(names, ",")
 	if !strings.Contains(got, "idx_keep") {
 		t.Errorf("index idx_keep lost after DropColumn, remaining: %v", names)
@@ -95,7 +97,9 @@ func TestRecreateTablePreservesIndexesAndTriggers(t *testing.T) {
 		t.Fatal(err)
 	}
 	var auditCount int
-	db.Raw("SELECT count(*) FROM rebuild_audit").Scan(&auditCount)
+	if err := db.Raw("SELECT count(*) FROM rebuild_audit").Scan(&auditCount).Error; err != nil {
+		t.Fatalf("querying rebuild_audit: %v", err)
+	}
 	if auditCount != 1 {
 		t.Errorf("trigger did not fire after rebuild, audit rows = %d", auditCount)
 	}
@@ -121,7 +125,9 @@ func TestRecreateTablePreservesTableOptions(t *testing.T) {
 	}
 
 	var ddl string
-	db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='rebuild_opts_table'").Scan(&ddl)
+	if err := db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='rebuild_opts_table'").Scan(&ddl).Error; err != nil {
+		t.Fatalf("querying sqlite_master: %v", err)
+	}
 	if !strings.Contains(ddl, "WITHOUT ROWID") {
 		t.Errorf("WITHOUT ROWID lost after rebuild: %s", ddl)
 	}
@@ -163,5 +169,12 @@ func openRecreateTestDB(t *testing.T, name string) *gorm.DB {
 	if err != nil {
 		t.Fatalf("gorm.Open: %v", err)
 	}
+	// close the pool so the shared in-memory database is torn down and
+	// repeated runs (go test -count=N) start from a clean state
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
 	return db
 }


### PR DESCRIPTION
### What this PR does

`recreateTable` implements ALTER TABLE operations by creating a modified copy of the table, moving the data over, dropping the original and renaming the copy back. Three kinds of schema objects were silently lost along the way:

**Indexes and triggers.** `DROP TABLE` removes them together with the old table. A full `AutoMigrate` happens to recreate the indexes declared in the model afterwards, but calling `AlterColumn`, `DropColumn` or the constraint methods directly loses every index and trigger on the table without any error.

**Table options after the column list.** The DDL parser only kept the head and the column list, so `WITHOUT ROWID` and `STRICT` disappeared on rebuild and the table silently became a plain rowid table.

**Views referencing the table** (#225). The RENAME step re-resolves referencing views while the original table name doesn't exist yet (it was just dropped), so the whole operation fails with `error in view ...: no such table`.

### The fix

- Before the rebuild, save the `sql` of every index and trigger on the table from `sqlite_master`, and replay them after the rename. Indexes referencing a dropped column can no longer apply and are skipped.
- The DDL parser now captures everything after the closing parenthesis into a `suffix` field and `compile()` emits it again, preserving `WITHOUT ROWID`/`STRICT`.
- The rename runs under `PRAGMA legacy_alter_table`, which skips the view re-resolution; the view points at the original table name and is valid again right after the rename. The PRAGMA is switched off immediately afterwards, whether the rename succeeds or fails.

### Tests

- `TestRecreateTablePreservesIndexesAndTriggers`: an index on a kept column and a trigger survive `DropColumn` (and the trigger still fires), while an index on the dropped column is removed.
- `TestRecreateTablePreservesTableOptions`: `WITHOUT ROWID` survives a rebuild.
- `TestRecreateTableWithView`: rebuilding a table referenced by a view succeeds and the view still works (reproduces #225).

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)