### PR TITLE
ci: test on Go 1.24 through 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go: ['1.21', '1.20', '1.19']
+        go: ['1.26', '1.25', '1.24']
         platform: [ubuntu-latest] # can not run in windows OS
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Why

CI is currently red on master and on every PR: the matrix still includes Go **1.19** and **1.20**, which are below the `go 1.21` requirement in `go.mod` and no longer compile the driver — `github.com/mattn/go-sqlite3 v1.14.48` (bumped in #239) uses `unsafe.StringData`, which was added in Go 1.20:

```
../go-sqlite3@v1.14.48/sqlite3.go:2196:68: undefined: unsafe.StringData
FAIL    gorm.io/driver/sqlite [build failed]
```

Example failing runs: [master](https://github.com/go-gorm/sqlite/actions/runs/30615277515), [#236](https://github.com/go-gorm/sqlite/actions/runs/30615658257).

### What

Update the matrix to the three most recent Go releases: **1.24, 1.25, 1.26**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)