### PR TITLE
fix(ddlmod): recognize the ? placeholder in constraint clauses

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -13,12 +13,11 @@ import (
 
 var (
 	sqliteSeparator    = "`|\"|'"
-	sqliteColumnQuote  = "`"
 	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?:CONSTRAINT [%v]?[\w-]+[%v]? )?UNIQUE (.*)$`, sqliteSeparator, sqliteSeparator))
 	indexRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)CREATE(?: UNIQUE)? INDEX [%v]?[\w\d-]+[%v]?(?s:.*?)ON (.*)$`, sqliteSeparator, sqliteSeparator))
 	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v]?[\w\d-]+[%v]?)(?:\s*\((.*)\))?(.*)$`, sqliteSeparator, sqliteSeparator))
 	checkRegexp        = regexp.MustCompile(`^(?i)CHECK[\s]*\(`)
-	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+%[1]s[\w\d_]+%[1]s[\s]+`, sqliteColumnQuote))
+	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v]?[\w\d_]+[%v]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
 	separatorRegexp    = regexp.MustCompile(fmt.Sprintf("[%v]", sqliteSeparator))
 	columnRegexp       = regexp.MustCompile(fmt.Sprintf(`^[%v]?([\w\d]+)[%v]?\s+([\w\(\)\d]+)(.*)$`, sqliteSeparator, sqliteSeparator))
 	defaultValueRegexp = regexp.MustCompile(`(?i) DEFAULT \(?(.+)?\)?( |COLLATE|GENERATED|$)`)

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -178,3 +178,58 @@ func openRecreateTestDB(t *testing.T, name string) *gorm.DB {
 	})
 	return db
 }
+
+type ConstraintParent struct {
+	ID int `gorm:"primaryKey"`
+}
+
+func (ConstraintParent) TableName() string { return "constraint_parents" }
+
+type ConstraintChild struct {
+	ID       int
+	ParentID int
+	Parent   ConstraintParent `gorm:"foreignKey:ParentID"`
+}
+
+func (ConstraintChild) TableName() string { return "constraint_children" }
+
+// CreateConstraint appends the constraint to the field list as a `CONSTRAINT ?
+// FOREIGN KEY ...` placeholder clause; getColumns must not mistake it for a
+// column, or the data copy fails with "no column named CONSTRAINT".
+func TestCreateConstraintPlaceholder(t *testing.T) {
+	db, err := gorm.Open(Open("file:constraint_placeholder?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	if err := db.AutoMigrate(&ConstraintParent{}); err != nil {
+		t.Fatal(err)
+	}
+	// existing table missing the foreign key declared in the model
+	if err := db.Exec("CREATE TABLE `constraint_children` (`id` integer, `parent_id` integer)").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec("INSERT INTO `constraint_children`(`id`,`parent_id`) VALUES (1, NULL)").Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.AutoMigrate(&ConstraintChild{}); err != nil {
+		t.Fatalf("AutoMigrate adding the missing foreign key: %v", err)
+	}
+
+	var n int
+	if err := db.Raw("SELECT count(*) FROM `constraint_children`").Scan(&n).Error; err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("rows after rebuild = %d, want 1", n)
+	}
+	if !db.Migrator().HasConstraint(&ConstraintChild{}, "fk_constraint_children_parent") {
+		t.Error("foreign key constraint missing after AutoMigrate")
+	}
+}


### PR DESCRIPTION
### Symptom

`AutoMigrate` on an existing table that is missing a foreign key declared in the model fails with:

```
table constraint_children__temp has no column named CONSTRAINT
```

### Cause

`CreateConstraint` appends the constraint to the DDL field list in the form produced by `constraint.Build()`: `CONSTRAINT ? FOREIGN KEY ...`. The `constraintRegexp` used by `getColumns` to filter out constraint clauses requires a **backquoted** constraint name, so the placeholder clause isn't recognized — the literal token `CONSTRAINT` is extracted as a column name and lands in the rebuild's `INSERT INTO ... SELECT`.

### Fix

Accept a quoted or unquoted name as well as the `?` placeholder, matching the more tolerant `compileConstraintRegexp` already used by `addConstraint`/`removeConstraint`. The now-unused `sqliteColumnQuote` is removed.

Covered by an end-to-end test: create the parent, create the child table without the FK, then `AutoMigrate` the child model — previously failing, now the constraint is added and data survives the rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Merge order** (this batch: #241 → #242 → #243 → #244 → #245 → #246, plus #234 from the previous batch): all seven are functionally independent and merge cleanly in any order. Several append tests to the same test files, so whichever merges later may show a trivial append-only conflict in `migrator_test.go`/`ddlmod_test.go` — I'll rebase the remaining ones promptly after each merge, as before.
