### PR TITLE
fix: quote string literals with single quotes in Explain

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -158,7 +158,7 @@ func parseDDL(strs ...string) (*ddl, error) {
 						if strings.ToLower(defaultMatches[1]) != "null" {
 							// single quotes are standard SQL string literals,
 							// double quotes come from tables created by older versions
-							columnType.DefaultValueValue = sql.NullString{String: strings.Trim(defaultMatches[1], `'"`), Valid: true}
+							columnType.DefaultValueValue = sql.NullString{String: trimQuote(defaultMatches[1]), Valid: true}
 						}
 					}
 
@@ -294,4 +294,15 @@ func (d *ddl) removeColumn(name string) bool {
 	}
 
 	return false
+}
+
+// trimQuote removes one pair of matching outer quotes from a default value
+// literal, so inner quotes of values like '"x"' survive.
+func trimQuote(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '\'' && s[len(s)-1] == '\'') || (s[0] == '"' && s[len(s)-1] == '"') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -156,7 +156,9 @@ func parseDDL(strs ...string) (*ddl, error) {
 					}
 					if defaultMatches := defaultValueRegexp.FindStringSubmatch(matches[3]); len(defaultMatches) > 1 {
 						if strings.ToLower(defaultMatches[1]) != "null" {
-							columnType.DefaultValueValue = sql.NullString{String: strings.Trim(defaultMatches[1], `"`), Valid: true}
+							// single quotes are standard SQL string literals,
+							// double quotes come from tables created by older versions
+							columnType.DefaultValueValue = sql.NullString{String: strings.Trim(defaultMatches[1], `'"`), Valid: true}
 						}
 					}
 

--- a/sqlite.go
+++ b/sqlite.go
@@ -203,7 +203,8 @@ func (dialector Dialector) QuoteTo(writer clause.Writer, str string) {
 }
 
 func (dialector Dialector) Explain(sql string, vars ...interface{}) string {
-	return logger.ExplainSQL(sql, nil, `"`, vars...)
+	// single quotes: double quotes are identifier quoting in SQLite
+	return logger.ExplainSQL(sql, nil, `'`, vars...)
 }
 
 func (dialector Dialector) DataTypeOf(field *schema.Field) string {

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mattn/go-sqlite3"
@@ -128,5 +129,69 @@ func TestDialector(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestExplainQuotesStrings(t *testing.T) {
+	out := Dialector{}.Explain("SELECT * FROM t WHERE name = ?", "hello")
+	if !strings.Contains(out, "'hello'") {
+		t.Errorf("Explain must quote string literals with single quotes, got: %s", out)
+	}
+}
+
+type explainDefaultModel struct {
+	ID   int
+	Code string `gorm:"default:hello"`
+}
+
+func (explainDefaultModel) TableName() string { return "explain_defaults" }
+
+// GORM embeds string default values into the DDL via Dialector.Explain;
+// parseDDL must strip the single quotes (and double quotes from tables
+// created by older versions) so migrations stay idempotent.
+func TestDefaultValueRoundTrip(t *testing.T) {
+	db, err := gorm.Open(Open("file:explain_defaults?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	if err := db.AutoMigrate(&explainDefaultModel{}); err != nil {
+		t.Fatal(err)
+	}
+	cols, err := db.Migrator().ColumnTypes(&explainDefaultModel{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cols {
+		if c.Name() == "code" {
+			if dv, ok := c.DefaultValue(); !ok || dv != "hello" {
+				t.Errorf("DefaultValue = (%q,%v), want (hello,true)", dv, ok)
+			}
+		}
+	}
+	// second AutoMigrate must not rebuild the table
+	var before string
+	db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='explain_defaults'").Scan(&before)
+	if err := db.AutoMigrate(&explainDefaultModel{}); err != nil {
+		t.Fatal(err)
+	}
+	var after string
+	db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='explain_defaults'").Scan(&after)
+	if before != after {
+		t.Errorf("DDL changed after second AutoMigrate:\n  before: %s\n  after:  %s", before, after)
+	}
+
+	// double quotes from tables created by older driver versions still parse
+	d, err := parseDDL("CREATE TABLE `legacy` (`code` text DEFAULT \"hi\")")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dv, ok := d.columns[0].DefaultValue(); !ok || dv != "hi" {
+		t.Errorf("legacy DefaultValue = (%q,%v), want (hi,true)", dv, ok)
 	}
 }

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -176,12 +176,16 @@ func TestDefaultValueRoundTrip(t *testing.T) {
 	}
 	// second AutoMigrate must not rebuild the table
 	var before string
-	db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='explain_defaults'").Scan(&before)
+	if err := db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='explain_defaults'").Scan(&before).Error; err != nil {
+		t.Fatal(err)
+	}
 	if err := db.AutoMigrate(&explainDefaultModel{}); err != nil {
 		t.Fatal(err)
 	}
 	var after string
-	db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='explain_defaults'").Scan(&after)
+	if err := db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='explain_defaults'").Scan(&after).Error; err != nil {
+		t.Fatal(err)
+	}
 	if before != after {
 		t.Errorf("DDL changed after second AutoMigrate:\n  before: %s\n  after:  %s", before, after)
 	}
@@ -193,5 +197,14 @@ func TestDefaultValueRoundTrip(t *testing.T) {
 	}
 	if dv, ok := d.columns[0].DefaultValue(); !ok || dv != "hi" {
 		t.Errorf("legacy DefaultValue = (%q,%v), want (hi,true)", dv, ok)
+	}
+
+	// only one outer quote pair is stripped; inner quotes survive
+	d, err = parseDDL("CREATE TABLE `q` (`code` text DEFAULT '\"x\"')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dv, ok := d.columns[0].DefaultValue(); !ok || dv != `"x"` {
+		t.Errorf(`quoted DefaultValue = (%q,%v), want ("x",true)`, dv, ok)
 	}
 }


### PR DESCRIPTION
### Symptom

`Explain` wraps string values in double quotes (`name = "hello"`), but double quotes are **identifier quoting** in SQLite — SQL copied from the logs misparses the value as a column reference (#197).

### Fix

Use standard single-quoted string literals in `Explain`.

One coupled change is required: GORM embeds string default values into `CREATE TABLE` DDL through `Dialector.Explain` (`FullDataTypeOf` → `DEFAULT 'hello'`), and the DDL parser only stripped **double** quotes from parsed default values. With Explain fixed in isolation, `DefaultValue()` would return `'hello'` with quotes and every `AutoMigrate` would try to re-alter the column. The parser now strips single quotes too, and keeps stripping double quotes so tables created by older driver versions still parse.

### Tests

- `TestExplainQuotesStrings` — literal quoting.
- `TestDefaultValueRoundTrip` — default value parses back clean, a second `AutoMigrate` leaves the DDL untouched, and a legacy double-quoted default still parses.

Fixes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Merge order** (this batch: #241 → #242 → #243 → #244 → #245 → #246, plus #234 from the previous batch): all seven are functionally independent and merge cleanly in any order. Several append tests to the same test files, so whichever merges later may show a trivial append-only conflict in `migrator_test.go`/`ddlmod_test.go` — I'll rebase the remaining ones promptly after each merge, as before.
