### PR TITLE
fix(Migrator): don't let rows.Close() overwrite ColumnTypes errors

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -127,7 +127,9 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 			return err
 		}
 		defer func() {
-			err = rows.Close()
+			if cerr := rows.Close(); err == nil {
+				err = cerr
+			}
 		}()
 
 		var rawColumnTypes []*sql.ColumnType


### PR DESCRIPTION
`ColumnTypes` defers `err = rows.Close()` onto its named return value, unconditionally replacing whatever error occurred after the rows were opened — an error from `rows.ColumnTypes()` or the merge loop is swallowed by the (almost always nil) `Close` result, and the caller sees success with incomplete data. Keep the first error, still surfacing a `Close` failure when nothing else went wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Merge order** (this batch: #241 → #242 → #243 → #244 → #245 → #246, plus #234 from the previous batch): all seven are functionally independent and merge cleanly in any order. Several append tests to the same test files, so whichever merges later may show a trivial append-only conflict in `migrator_test.go`/`ddlmod_test.go` — I'll rebase the remaining ones promptly after each merge, as before.
