### PR TITLE
fix: migrator and DDL parsing fixes (consolidates #234, #241–#245)

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	sqliteSeparator    = "`|\"|'"
-	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?:CONSTRAINT [%v]?[\w-]+[%v]? )?UNIQUE (.*)$`, sqliteSeparator, sqliteSeparator))
+	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?i)(?:CONSTRAINT [%v]?[\w-]+[%v]? )?UNIQUE\s*(\(.*)$`, sqliteSeparator, sqliteSeparator))
 	indexRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)CREATE(?: UNIQUE)? INDEX [%v]?[\w\d-]+[%v]?(?s:.*?)ON (.*)$`, sqliteSeparator, sqliteSeparator))
 	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v]?[\w\d-]+[%v]?)(?:\s*\((.*)\))?(.*)$`, sqliteSeparator, sqliteSeparator))
 	checkRegexp        = regexp.MustCompile(`^(?i)CHECK[\s]*\(`)
@@ -223,7 +223,9 @@ func (d *ddl) renameTable(dst, src string) error {
 }
 
 func compileConstraintRegexp(name string) *regexp.Regexp {
-	return regexp.MustCompile("^(?i:CONSTRAINT)\\s+[\"`]?" + regexp.QuoteMeta(name) + "[\"`\\s]")
+	// the name may be quoted with backquotes, double quotes, single quotes
+	// or brackets, or not at all
+	return regexp.MustCompile("^(?i:CONSTRAINT)\\s+[\"'`\\[]?" + regexp.QuoteMeta(name) + "[\"'`\\]\\s]")
 }
 
 func (d *ddl) addConstraint(name string, sql string) {
@@ -288,7 +290,7 @@ func (d *ddl) getColumns() []string {
 }
 
 func (d *ddl) removeColumn(name string) bool {
-	reg := regexp.MustCompile("^(`|'|\"| )" + regexp.QuoteMeta(name) + "(`|'|\"| ) .*?$")
+	reg := regexp.MustCompile("^[`'\" ]?" + regexp.QuoteMeta(name) + "[`'\" ]")
 
 	for i := 0; i < len(d.fields); i++ {
 		if reg.MatchString(d.fields[i]) {

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -13,13 +13,13 @@ import (
 
 var (
 	sqliteSeparator    = "`|\"|'"
-	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?i)(?:CONSTRAINT [%v\[]?[\w-]+[%v\]]? )?UNIQUE\s*(\(.*)$`, sqliteSeparator, sqliteSeparator))
-	indexRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)CREATE(?: UNIQUE)? INDEX [%v]?[\w\d-]+[%v]?(?s:.*?)ON (.*)$`, sqliteSeparator, sqliteSeparator))
-	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v]?[\w\d-]+[%v]?)(?:\s*\((.*)\))?(.*)$`, sqliteSeparator, sqliteSeparator))
+	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?i)(?:CONSTRAINT [%v\[]?[\p{L}\p{N}_-]+[%v\]]? )?UNIQUE\s*(\(.*)$`, sqliteSeparator, sqliteSeparator))
+	indexRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)CREATE(?: UNIQUE)? INDEX [%v\[]?[\p{L}\p{N}_-]+[%v\]]?(?s:.*?)ON (.*)$`, sqliteSeparator, sqliteSeparator))
+	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v\[]?[\w\d-]+[%v\]]?)(?:\s*\((.*)\))?(.*)$`, sqliteSeparator, sqliteSeparator))
 	checkRegexp        = regexp.MustCompile(`^(?i)CHECK[\s]*\(`)
 	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v\[]?[\p{L}\p{N}_-]+[%v\]]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
 	separatorRegexp    = regexp.MustCompile(fmt.Sprintf("[%v]", sqliteSeparator))
-	columnRegexp       = regexp.MustCompile(fmt.Sprintf(`^[%v]?([\w\d]+)[%v]?\s+(\w+(?:\([^)]*\))?)(.*)$`, sqliteSeparator, sqliteSeparator))
+	columnRegexp       = regexp.MustCompile(fmt.Sprintf(`^[%v\[]?([\p{L}\p{N}_]+)[%v\]]?\s+(\w+(?:\([^)]*\))?)(.*)$`, sqliteSeparator, sqliteSeparator))
 	defaultValueRegexp = regexp.MustCompile(`(?i) DEFAULT \(?(.+)?\)?( |COLLATE|GENERATED|$)`)
 	typeSizeRegexp     = regexp.MustCompile(`\((\d+)\s*(?:,\s*(\d+))?\)$`)
 )
@@ -208,7 +208,10 @@ func (d *ddl) compile() string {
 }
 
 func (d *ddl) renameTable(dst, src string) error {
-	tableReg, err := regexp.Compile("\\s*('|`|\")?\\b" + regexp.QuoteMeta(src) + "\\b('|`|\")?\\s*")
+	// the name may be quoted with single quotes, backquotes, double quotes or
+	// brackets; the closing bracket has to be consumed too, or the rewritten
+	// head keeps it and yields [`dst`]
+	tableReg, err := regexp.Compile("\\s*('|`|\"|\\[)?\\b" + regexp.QuoteMeta(src) + "\\b('|`|\"|\\])?\\s*")
 	if err != nil {
 		return err
 	}
@@ -279,7 +282,7 @@ func (d *ddl) getColumns() []string {
 			continue
 		}
 
-		reg := regexp.MustCompile("^[\"`'\\[]?([\\w\\d]+)[\"`'\\]]?")
+		reg := regexp.MustCompile("^[\"`'\\[]?([\\p{L}\\p{N}_]+)[\"`'\\]]?")
 		match := reg.FindStringSubmatch(f)
 
 		if match != nil {

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -13,12 +13,11 @@ import (
 
 var (
 	sqliteSeparator    = "`|\"|'"
-	sqliteColumnQuote  = "`"
 	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?:CONSTRAINT [%v]?[\w-]+[%v]? )?UNIQUE (.*)$`, sqliteSeparator, sqliteSeparator))
 	indexRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)CREATE(?: UNIQUE)? INDEX [%v]?[\w\d-]+[%v]?(?s:.*?)ON (.*)$`, sqliteSeparator, sqliteSeparator))
 	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v]?[\w\d-]+[%v]?)(?:\s*\((.*)\))?(.*)$`, sqliteSeparator, sqliteSeparator))
 	checkRegexp        = regexp.MustCompile(`^(?i)CHECK[\s]*\(`)
-	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+%[1]s[\w\d_]+%[1]s[\s]+`, sqliteColumnQuote))
+	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v]?[\w\d_]+[%v]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
 	separatorRegexp    = regexp.MustCompile(fmt.Sprintf("[%v]", sqliteSeparator))
 	columnRegexp       = regexp.MustCompile(fmt.Sprintf(`^[%v]?([\w\d]+)[%v]?\s+([\w\(\)\d]+)(.*)$`, sqliteSeparator, sqliteSeparator))
 	defaultValueRegexp = regexp.MustCompile(`(?i) DEFAULT \(?(.+)?\)?( |COLLATE|GENERATED|$)`)

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -17,7 +17,7 @@ var (
 	indexRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)CREATE(?: UNIQUE)? INDEX [%v]?[\w\d-]+[%v]?(?s:.*?)ON (.*)$`, sqliteSeparator, sqliteSeparator))
 	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v]?[\w\d-]+[%v]?)(?:\s*\((.*)\))?(.*)$`, sqliteSeparator, sqliteSeparator))
 	checkRegexp        = regexp.MustCompile(`^(?i)CHECK[\s]*\(`)
-	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v\[]?[\w\d_-]+[%v\]]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
+	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v\[]?[\p{L}\p{N}_-]+[%v\]]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
 	separatorRegexp    = regexp.MustCompile(fmt.Sprintf("[%v]", sqliteSeparator))
 	columnRegexp       = regexp.MustCompile(fmt.Sprintf(`^[%v]?([\w\d]+)[%v]?\s+(\w+(?:\([^)]*\))?)(.*)$`, sqliteSeparator, sqliteSeparator))
 	defaultValueRegexp = regexp.MustCompile(`(?i) DEFAULT \(?(.+)?\)?( |COLLATE|GENERATED|$)`)

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -155,7 +155,9 @@ func parseDDL(strs ...string) (*ddl, error) {
 					}
 					if defaultMatches := defaultValueRegexp.FindStringSubmatch(matches[3]); len(defaultMatches) > 1 {
 						if strings.ToLower(defaultMatches[1]) != "null" {
-							columnType.DefaultValueValue = sql.NullString{String: strings.Trim(defaultMatches[1], `"`), Valid: true}
+							// single quotes are standard SQL string literals,
+							// double quotes come from tables created by older versions
+							columnType.DefaultValueValue = sql.NullString{String: trimQuote(defaultMatches[1]), Valid: true}
 						}
 					}
 
@@ -291,4 +293,15 @@ func (d *ddl) removeColumn(name string) bool {
 	}
 
 	return false
+}
+
+// trimQuote removes one pair of matching outer quotes from a default value
+// literal, so inner quotes of values like '"x"' survive.
+func trimQuote(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '\'' && s[len(s)-1] == '\'') || (s[0] == '"' && s[len(s)-1] == '"') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -17,7 +17,7 @@ var (
 	indexRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)CREATE(?: UNIQUE)? INDEX [%v]?[\w\d-]+[%v]?(?s:.*?)ON (.*)$`, sqliteSeparator, sqliteSeparator))
 	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v]?[\w\d-]+[%v]?)(?:\s*\((.*)\))?(.*)$`, sqliteSeparator, sqliteSeparator))
 	checkRegexp        = regexp.MustCompile(`^(?i)CHECK[\s]*\(`)
-	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v\[]?[\w\d_]+[%v\]]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
+	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v\[]?[\w\d_-]+[%v\]]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
 	separatorRegexp    = regexp.MustCompile(fmt.Sprintf("[%v]", sqliteSeparator))
 	columnRegexp       = regexp.MustCompile(fmt.Sprintf(`^[%v]?([\w\d]+)[%v]?\s+(\w+(?:\([^)]*\))?)(.*)$`, sqliteSeparator, sqliteSeparator))
 	defaultValueRegexp = regexp.MustCompile(`(?i) DEFAULT \(?(.+)?\)?( |COLLATE|GENERATED|$)`)
@@ -279,7 +279,7 @@ func (d *ddl) getColumns() []string {
 			continue
 		}
 
-		reg := regexp.MustCompile("^[\"`']?([\\w\\d]+)[\"`']?")
+		reg := regexp.MustCompile("^[\"`'\\[]?([\\w\\d]+)[\"`'\\]]?")
 		match := reg.FindStringSubmatch(f)
 
 		if match != nil {
@@ -290,7 +290,7 @@ func (d *ddl) getColumns() []string {
 }
 
 func (d *ddl) removeColumn(name string) bool {
-	reg := regexp.MustCompile("^[`'\" ]?" + regexp.QuoteMeta(name) + "[`'\" ]")
+	reg := regexp.MustCompile("^[`'\"\\[ ]?" + regexp.QuoteMeta(name) + "[`'\"\\] ]")
 
 	for i := 0; i < len(d.fields); i++ {
 		if reg.MatchString(d.fields[i]) {

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -13,11 +13,11 @@ import (
 
 var (
 	sqliteSeparator    = "`|\"|'"
-	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?i)(?:CONSTRAINT [%v]?[\w-]+[%v]? )?UNIQUE\s*(\(.*)$`, sqliteSeparator, sqliteSeparator))
+	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?i)(?:CONSTRAINT [%v\[]?[\w-]+[%v\]]? )?UNIQUE\s*(\(.*)$`, sqliteSeparator, sqliteSeparator))
 	indexRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)CREATE(?: UNIQUE)? INDEX [%v]?[\w\d-]+[%v]?(?s:.*?)ON (.*)$`, sqliteSeparator, sqliteSeparator))
 	tableRegexp        = regexp.MustCompile(fmt.Sprintf(`(?is)(CREATE TABLE [%v]?[\w\d-]+[%v]?)(?:\s*\((.*)\))?(.*)$`, sqliteSeparator, sqliteSeparator))
 	checkRegexp        = regexp.MustCompile(`^(?i)CHECK[\s]*\(`)
-	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v]?[\w\d_]+[%v]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
+	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v\[]?[\w\d_]+[%v\]]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
 	separatorRegexp    = regexp.MustCompile(fmt.Sprintf("[%v]", sqliteSeparator))
 	columnRegexp       = regexp.MustCompile(fmt.Sprintf(`^[%v]?([\w\d]+)[%v]?\s+(\w+(?:\([^)]*\))?)(.*)$`, sqliteSeparator, sqliteSeparator))
 	defaultValueRegexp = regexp.MustCompile(`(?i) DEFAULT \(?(.+)?\)?( |COLLATE|GENERATED|$)`)

--- a/ddlmod.go
+++ b/ddlmod.go
@@ -19,9 +19,9 @@ var (
 	checkRegexp        = regexp.MustCompile(`^(?i)CHECK[\s]*\(`)
 	constraintRegexp   = regexp.MustCompile(fmt.Sprintf(`^(?i)CONSTRAINT\s+(?:[%v]?[\w\d_]+[%v]?|\?)\s+`, sqliteSeparator, sqliteSeparator))
 	separatorRegexp    = regexp.MustCompile(fmt.Sprintf("[%v]", sqliteSeparator))
-	columnRegexp       = regexp.MustCompile(fmt.Sprintf(`^[%v]?([\w\d]+)[%v]?\s+([\w\(\)\d]+)(.*)$`, sqliteSeparator, sqliteSeparator))
+	columnRegexp       = regexp.MustCompile(fmt.Sprintf(`^[%v]?([\w\d]+)[%v]?\s+(\w+(?:\([^)]*\))?)(.*)$`, sqliteSeparator, sqliteSeparator))
 	defaultValueRegexp = regexp.MustCompile(`(?i) DEFAULT \(?(.+)?\)?( |COLLATE|GENERATED|$)`)
-	regRealDataType    = regexp.MustCompile(`[^\d](\d+)[^\d]?`)
+	typeSizeRegexp     = regexp.MustCompile(`\((\d+)\s*(?:,\s*(\d+))?\)$`)
 )
 
 type ddl struct {
@@ -161,12 +161,17 @@ func parseDDL(strs ...string) (*ddl, error) {
 						}
 					}
 
-					// data type length
-					matches := regRealDataType.FindAllStringSubmatch(columnType.DataTypeValue.String, -1)
-					if len(matches) == 1 && len(matches[0]) == 2 {
-						size, _ := strconv.Atoi(matches[0][1])
-						columnType.LengthValue = sql.NullInt64{Valid: true, Int64: int64(size)}
-						columnType.DataTypeValue.String = strings.TrimSuffix(columnType.DataTypeValue.String, matches[0][0])
+					// data type length / precision, e.g. varchar(10), decimal(10,2)
+					if sizeMatches := typeSizeRegexp.FindStringSubmatch(columnType.DataTypeValue.String); sizeMatches != nil {
+						size, _ := strconv.Atoi(sizeMatches[1])
+						if sizeMatches[2] != "" {
+							scale, _ := strconv.Atoi(sizeMatches[2])
+							columnType.DecimalSizeValue = sql.NullInt64{Valid: true, Int64: int64(size)}
+							columnType.ScaleValue = sql.NullInt64{Valid: true, Int64: int64(scale)}
+						} else {
+							columnType.LengthValue = sql.NullInt64{Valid: true, Int64: int64(size)}
+						}
+						columnType.DataTypeValue.String = strings.TrimSuffix(columnType.DataTypeValue.String, sizeMatches[0])
 					}
 
 					result.columns = append(result.columns, columnType)

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -2,6 +2,8 @@ package sqlite
 
 import (
 	"database/sql"
+	"reflect"
+	"strings"
 	"testing"
 
 	"gorm.io/gorm/migrator"
@@ -553,6 +555,80 @@ func TestConstraintNameQuoting(t *testing.T) {
 	}
 }
 
+// Column names carry the same quoting forms as constraint names, and SQLite
+// identifiers are not restricted to ASCII. A column the parser does not see is
+// dropped from the rebuild's copy list, so its data is lost.
+func TestParseDDL_ColumnIdentifiers(t *testing.T) {
+	forms := []struct {
+		desc, ddl string
+		want      []string
+	}{
+		{"backquotes", "CREATE TABLE `t` (`a` integer, `b` text)", []string{"`a`", "`b`"}},
+		{"double quotes", `CREATE TABLE "t" ("a" integer, "b" text)`, []string{"`a`", "`b`"}},
+		{"brackets", "CREATE TABLE t ([a] integer, [b] text)", []string{"`a`", "`b`"}},
+		{"unquoted", "CREATE TABLE t (a integer, b text)", []string{"`a`", "`b`"}},
+		{"non-ASCII", "CREATE TABLE `t` (`用户名` text, `b` integer)", []string{"`用户名`", "`b`"}},
+	}
+	for _, f := range forms {
+		d, err := parseDDL(f.ddl)
+		if err != nil {
+			t.Fatalf("%s: %v", f.desc, err)
+		}
+		if cols := d.getColumns(); !reflect.DeepEqual(cols, f.want) {
+			t.Errorf("%s: getColumns = %v, want %v", f.desc, cols, f.want)
+		}
+		if len(d.columns) != len(f.want) {
+			t.Errorf("%s: parsed %d columns, want %d", f.desc, len(d.columns), len(f.want))
+		}
+	}
+}
+
+// ColumnTypes feeds parseDDL the table DDL together with every index DDL, so an
+// index name the parser cannot read fails the whole call with "invalid DDL".
+func TestParseDDL_IndexIdentifiers(t *testing.T) {
+	forms := map[string]string{
+		"backquotes": "CREATE INDEX `idx_a` ON `t`(`a`)",
+		"brackets":   "CREATE INDEX [idx_a] ON [t]([a])",
+		"unquoted":   "CREATE INDEX idx_a ON t(a)",
+		"non-ASCII":  "CREATE INDEX `索引_a` ON `t`(`a`)",
+		"unique":     "CREATE UNIQUE INDEX [idx_b] ON [t]([b])",
+	}
+	for form, ddlSQL := range forms {
+		if _, err := parseDDL("CREATE TABLE `t` (`a` integer, `b` text)", ddlSQL); err != nil {
+			t.Errorf("%s: %v", form, err)
+		}
+	}
+}
+
+// A bracket-quoted table name must parse and rebuild like the other forms.
+// renameTable has to consume the brackets as well, or the rewritten head
+// becomes [`t__temp`], naming a table with literal backquotes in it.
+func TestParseDDL_TableIdentifiers(t *testing.T) {
+	forms := map[string]string{
+		"backquotes":    "CREATE TABLE `t` (`a` integer, `b` text)",
+		"double quotes": `CREATE TABLE "t" ("a" integer, "b" text)`,
+		"single quotes": "CREATE TABLE 't' (`a` integer, `b` text)",
+		"brackets":      "CREATE TABLE [t] ([a] integer, [b] text)",
+		"unquoted":      "CREATE TABLE t (a integer, b text)",
+	}
+	for form, ddlSQL := range forms {
+		d, err := parseDDL(ddlSQL)
+		if err != nil {
+			t.Fatalf("%s: %v", form, err)
+		}
+		if err := d.renameTable("t__temp", "t"); err != nil {
+			t.Errorf("%s: renameTable: %v", form, err)
+			continue
+		}
+		if !strings.Contains(d.head, "`t__temp`") {
+			t.Errorf("%s: renamed head = %q, want it to quote t__temp", form, d.head)
+		}
+		if strings.ContainsAny(d.head, "[]") {
+			t.Errorf("%s: renamed head still carries the old brackets: %q", form, d.head)
+		}
+	}
+}
+
 // removeColumn matches the column name against the raw DDL field, so it has to
 // cope with every identifier quoting form. A false return now makes DropColumn
 // fail, so a missed match is no longer a silent no-op.
@@ -587,6 +663,7 @@ func TestUniqueConstraintNameQuoting(t *testing.T) {
 		"single quotes": "CREATE TABLE `t` (`a` integer, CONSTRAINT 'u_a' UNIQUE (`a`))",
 		"brackets":      "CREATE TABLE t (a integer, CONSTRAINT [u_a] UNIQUE (a))",
 		"unquoted":      "CREATE TABLE t (a integer, CONSTRAINT u_a UNIQUE (a))",
+		"non-ASCII":     "CREATE TABLE `t` (`a` integer, CONSTRAINT `唯一_a` UNIQUE (`a`))",
 	}
 	for form, ddlSQL := range forms {
 		d, err := parseDDL(ddlSQL)

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -540,5 +540,44 @@ func TestConstraintNameQuoting(t *testing.T) {
 		if d.hasConstraint("chk") {
 			t.Errorf("%s: prefix chk must not match", form)
 		}
+		// the clause must not be mistaken for a column, or the rebuild's
+		// data copy fails with "no column named CONSTRAINT"
+		if cols := d.getColumns(); len(cols) != 1 || cols[0] != "`a`" {
+			t.Errorf("%s: getColumns = %v, want [`a`]", form, cols)
+		}
+	}
+}
+
+// A table-level UNIQUE constraint marks its columns unique whichever way the
+// constraint name is quoted.
+func TestUniqueConstraintNameQuoting(t *testing.T) {
+	forms := map[string]string{
+		"backquotes":    "CREATE TABLE `t` (`a` integer, CONSTRAINT `u_a` UNIQUE (`a`))",
+		"double quotes": `CREATE TABLE "t" ("a" integer, CONSTRAINT "u_a" UNIQUE ("a"))`,
+		"single quotes": "CREATE TABLE `t` (`a` integer, CONSTRAINT 'u_a' UNIQUE (`a`))",
+		"brackets":      "CREATE TABLE t (a integer, CONSTRAINT [u_a] UNIQUE (a))",
+		"unquoted":      "CREATE TABLE t (a integer, CONSTRAINT u_a UNIQUE (a))",
+	}
+	for form, ddlSQL := range forms {
+		d, err := parseDDL(ddlSQL)
+		if err != nil {
+			t.Fatalf("%s: %v", form, err)
+		}
+		found := false
+		for _, c := range d.columns {
+			if c.NameValue.String != "a" {
+				continue
+			}
+			found = true
+			if uniq, _ := c.Unique(); !uniq {
+				t.Errorf("%s: column a not marked unique", form)
+			}
+		}
+		if !found {
+			t.Fatalf("%s: column a was not parsed at all", form)
+		}
+		if cols := d.getColumns(); len(cols) != 1 || cols[0] != "`a`" {
+			t.Errorf("%s: getColumns = %v, want [`a`]", form, cols)
+		}
 	}
 }

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -475,3 +475,30 @@ func TestGetColumns(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDDL_TypePrecision(t *testing.T) {
+	d, err := parseDDL("CREATE TABLE `t` (`p` decimal(10,2), `s` decimal(10, 2), `v` varchar(25))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range d.columns {
+		switch c.NameValue.String {
+		case "p", "s":
+			if c.DataTypeValue.String != "decimal" {
+				t.Errorf("%s: DataType = %q, want decimal", c.NameValue.String, c.DataTypeValue.String)
+			}
+			precision, scale, ok := c.DecimalSize()
+			if !ok || precision != 10 || scale != 2 {
+				t.Errorf("%s: DecimalSize = (%d,%d,%v), want (10,2,true)", c.NameValue.String, precision, scale, ok)
+			}
+		case "v":
+			if length, ok := c.Length(); !ok || length != 25 {
+				t.Errorf("v: Length = (%d,%v), want (25,true)", length, ok)
+			}
+		}
+	}
+	// the full column type is preserved for the first form
+	if ct, _ := d.columns[0].ColumnType(); ct != "decimal(10,2)" {
+		t.Errorf("ColumnType = %q, want decimal(10,2)", ct)
+	}
+}

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -502,3 +502,43 @@ func TestParseDDL_TypePrecision(t *testing.T) {
 		t.Errorf("ColumnType = %q, want decimal(10,2)", ct)
 	}
 }
+
+func TestParseDDL_LowercaseUnique(t *testing.T) {
+	d, err := parseDDL("CREATE TABLE `t` (`a` text, unique(`a`))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, c := range d.columns {
+		if c.NameValue.String == "a" {
+			found = true
+			if uniq, _ := c.Unique(); !uniq {
+				t.Error("lowercase table-level unique(...) not recognized")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("column a was not parsed at all")
+	}
+}
+
+func TestConstraintNameQuoting(t *testing.T) {
+	forms := map[string]string{
+		"backquotes":    "CREATE TABLE `t` (`a` integer, CONSTRAINT `chk_a` CHECK (`a` > 0))",
+		"double quotes": `CREATE TABLE "t" ("a" integer, CONSTRAINT "chk_a" CHECK ("a" > 0))`,
+		"brackets":      "CREATE TABLE t (a integer, CONSTRAINT [chk_a] CHECK (a > 0))",
+		"unquoted":      "CREATE TABLE t (a integer, CONSTRAINT chk_a CHECK (a > 0))",
+	}
+	for form, ddlSQL := range forms {
+		d, err := parseDDL(ddlSQL)
+		if err != nil {
+			t.Fatalf("%s: %v", form, err)
+		}
+		if !d.hasConstraint("chk_a") {
+			t.Errorf("%s: constraint chk_a not matched", form)
+		}
+		if d.hasConstraint("chk") {
+			t.Errorf("%s: prefix chk must not match", form)
+		}
+	}
+}

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -523,27 +523,56 @@ func TestParseDDL_LowercaseUnique(t *testing.T) {
 }
 
 func TestConstraintNameQuoting(t *testing.T) {
+	forms := []struct {
+		desc, ddl, name string
+	}{
+		{"backquotes", "CREATE TABLE `t` (`a` integer, CONSTRAINT `chk_a` CHECK (`a` > 0))", "chk_a"},
+		{"double quotes", `CREATE TABLE "t" ("a" integer, CONSTRAINT "chk_a" CHECK ("a" > 0))`, "chk_a"},
+		{"single quotes", "CREATE TABLE `t` (`a` integer, CONSTRAINT 'chk_a' CHECK (`a` > 0))", "chk_a"},
+		{"brackets", "CREATE TABLE t (a integer, CONSTRAINT [chk_a] CHECK (a > 0))", "chk_a"},
+		{"unquoted", "CREATE TABLE t (a integer, CONSTRAINT chk_a CHECK (a > 0))", "chk_a"},
+		{"hyphenated name", "CREATE TABLE `t` (`a` integer, CONSTRAINT `chk-a` CHECK (`a` > 0))", "chk-a"},
+	}
+	for _, f := range forms {
+		d, err := parseDDL(f.ddl)
+		if err != nil {
+			t.Fatalf("%s: %v", f.desc, err)
+		}
+		if !d.hasConstraint(f.name) {
+			t.Errorf("%s: constraint %s not matched", f.desc, f.name)
+		}
+		if d.hasConstraint("chk") {
+			t.Errorf("%s: prefix chk must not match", f.desc)
+		}
+		// the clause must not be mistaken for a column, or the rebuild's
+		// data copy fails with "no column named CONSTRAINT"
+		if cols := d.getColumns(); len(cols) != 1 || cols[0] != "`a`" {
+			t.Errorf("%s: getColumns = %v, want [`a`]", f.desc, cols)
+		}
+	}
+}
+
+// removeColumn matches the column name against the raw DDL field, so it has to
+// cope with every identifier quoting form. A false return now makes DropColumn
+// fail, so a missed match is no longer a silent no-op.
+func TestRemoveColumnQuotingForms(t *testing.T) {
 	forms := map[string]string{
-		"backquotes":    "CREATE TABLE `t` (`a` integer, CONSTRAINT `chk_a` CHECK (`a` > 0))",
-		"double quotes": `CREATE TABLE "t" ("a" integer, CONSTRAINT "chk_a" CHECK ("a" > 0))`,
-		"brackets":      "CREATE TABLE t (a integer, CONSTRAINT [chk_a] CHECK (a > 0))",
-		"unquoted":      "CREATE TABLE t (a integer, CONSTRAINT chk_a CHECK (a > 0))",
+		"backquotes":    "CREATE TABLE `t` (`a` integer, `b` text)",
+		"double quotes": `CREATE TABLE "t" ("a" integer, "b" text)`,
+		"single quotes": "CREATE TABLE `t` (`a` integer, 'b' text)",
+		"brackets":      "CREATE TABLE t ([a] integer, [b] text)",
+		"unquoted":      "CREATE TABLE t (a integer, b text)",
 	}
 	for form, ddlSQL := range forms {
 		d, err := parseDDL(ddlSQL)
 		if err != nil {
 			t.Fatalf("%s: %v", form, err)
 		}
-		if !d.hasConstraint("chk_a") {
-			t.Errorf("%s: constraint chk_a not matched", form)
+		if !d.removeColumn("b") {
+			t.Errorf("%s: removeColumn(b) = false, want true", form)
 		}
-		if d.hasConstraint("chk") {
-			t.Errorf("%s: prefix chk must not match", form)
-		}
-		// the clause must not be mistaken for a column, or the rebuild's
-		// data copy fails with "no column named CONSTRAINT"
 		if cols := d.getColumns(); len(cols) != 1 || cols[0] != "`a`" {
-			t.Errorf("%s: getColumns = %v, want [`a`]", form, cols)
+			t.Errorf("%s: getColumns after removal = %v, want [`a`]", form, cols)
 		}
 	}
 }

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -532,6 +532,7 @@ func TestConstraintNameQuoting(t *testing.T) {
 		{"brackets", "CREATE TABLE t (a integer, CONSTRAINT [chk_a] CHECK (a > 0))", "chk_a"},
 		{"unquoted", "CREATE TABLE t (a integer, CONSTRAINT chk_a CHECK (a > 0))", "chk_a"},
 		{"hyphenated name", "CREATE TABLE `t` (`a` integer, CONSTRAINT `chk-a` CHECK (`a` > 0))", "chk-a"},
+		{"non-ASCII name", "CREATE TABLE `t` (`a` integer, CONSTRAINT `检查_a` CHECK (`a` > 0))", "检查_a"},
 	}
 	for _, f := range forms {
 		d, err := parseDDL(f.ddl)

--- a/migrator.go
+++ b/migrator.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -52,7 +53,9 @@ func (m Migrator) DropTable(values ...interface{}) error {
 }
 
 func (m Migrator) GetTables() (tableList []string, err error) {
-	return tableList, m.DB.Raw("SELECT name FROM sqlite_master where type=?", "table").Scan(&tableList).Error
+	return tableList, m.DB.Raw(
+		"SELECT name FROM sqlite_master WHERE type = ? AND name NOT LIKE ?", "table", "sqlite_%",
+	).Scan(&tableList).Error
 }
 
 func (m Migrator) HasColumn(value interface{}, name string) bool {
@@ -168,7 +171,9 @@ func (m Migrator) DropColumn(value interface{}, name string) error {
 				}
 			}
 
-			ddl.removeColumn(name)
+			if !ddl.removeColumn(name) {
+				return nil, nil, fmt.Errorf("failed to drop column %v: not found in the DDL of table %v", name, stmt.Table)
+			}
 			return ddl, nil, nil
 		})
 	})
@@ -215,22 +220,26 @@ func (m Migrator) DropConstraint(value interface{}, name string) error {
 }
 
 func (m Migrator) HasConstraint(value interface{}, name string) bool {
-	var count int64
+	var has bool
 	m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		constraint, table := m.GuessConstraintInterfaceAndTable(stmt, name)
 		if constraint != nil {
 			name = constraint.GetName()
 		}
 
-		m.DB.Raw(
-			"SELECT count(*) FROM sqlite_master WHERE type = ? AND tbl_name = ? AND (sql LIKE ? OR sql LIKE ? OR sql LIKE ? OR sql LIKE ? OR sql LIKE ?)",
-			"table", table, `%CONSTRAINT "`+name+`" %`, `%CONSTRAINT `+name+` %`, "%CONSTRAINT `"+name+"`%", "%CONSTRAINT ["+name+"]%", "%CONSTRAINT \t"+name+"\t%",
-		).Row().Scan(&count)
-
+		rawDDL, err := m.getRawDDL(table)
+		if err != nil {
+			return err
+		}
+		parsed, err := parseDDL(rawDDL)
+		if err != nil {
+			return err
+		}
+		has = parsed.hasConstraint(name)
 		return nil
 	})
 
-	return count > 0
+	return has
 }
 
 func (m Migrator) CurrentDatabase() (name string) {
@@ -374,10 +383,13 @@ func (m Migrator) GetIndexes(value interface{}) ([]gorm.Index, error) {
 
 func (m Migrator) getRawDDL(table string) (string, error) {
 	var createSQL string
-	m.DB.Raw("SELECT sql FROM sqlite_master WHERE type = ? AND tbl_name = ? AND name = ?", "table", table, table).Row().Scan(&createSQL)
+	err := m.DB.Raw("SELECT sql FROM sqlite_master WHERE type = ? AND tbl_name = ? AND name = ?", "table", table, table).Row().Scan(&createSQL)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
 
-	if m.DB.Error != nil {
-		return "", m.DB.Error
+	if createSQL == "" {
+		return "", fmt.Errorf("failed to get DDL of table %q: table not found", table)
 	}
 	return createSQL, nil
 }

--- a/migrator.go
+++ b/migrator.go
@@ -78,6 +78,9 @@ func (m Migrator) HasColumn(value interface{}, name string) bool {
 func (m Migrator) AlterColumn(value interface{}, name string) error {
 	return m.RunWithoutForeignKey(func() error {
 		return m.recreateTable(value, nil, func(ddl *ddl, stmt *gorm.Statement) (*ddl, []interface{}, error) {
+			if stmt.Schema == nil {
+				return nil, nil, fmt.Errorf("failed to alter field with name %v: model with schema is required", name)
+			}
 			if field := stmt.Schema.LookUpField(name); field != nil {
 				var sqlArgs []interface{}
 				for i, f := range ddl.fields {
@@ -157,8 +160,10 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 func (m Migrator) DropColumn(value interface{}, name string) error {
 	return m.RunWithoutForeignKey(func() error {
 		return m.recreateTable(value, nil, func(ddl *ddl, stmt *gorm.Statement) (*ddl, []interface{}, error) {
-			if field := stmt.Schema.LookUpField(name); field != nil {
-				name = field.DBName
+			if stmt.Schema != nil {
+				if field := stmt.Schema.LookUpField(name); field != nil {
+					name = field.DBName
+				}
 			}
 
 			ddl.removeColumn(name)

--- a/migrator.go
+++ b/migrator.go
@@ -130,7 +130,9 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 			return err
 		}
 		defer func() {
-			err = rows.Close()
+			if cerr := rows.Close(); err == nil {
+				err = cerr
+			}
 		}()
 
 		var rawColumnTypes []*sql.ColumnType

--- a/migrator.go
+++ b/migrator.go
@@ -227,13 +227,16 @@ func (m Migrator) HasConstraint(value interface{}, name string) bool {
 			name = constraint.GetName()
 		}
 
+		// the result is a plain bool, so a missing table or a DDL this parser
+		// cannot read means "no such constraint" rather than an error to
+		// propagate; returning one here would only be discarded below
 		rawDDL, err := m.getRawDDL(table)
 		if err != nil {
-			return err
+			return nil
 		}
 		parsed, err := parseDDL(rawDDL)
 		if err != nil {
-			return err
+			return nil
 		}
 		has = parsed.hasConstraint(name)
 		return nil

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -302,3 +302,101 @@ func TestCompositePrimaryKeyAutoIncrement(t *testing.T) {
 		t.Errorf("primary key column count = %d, want 2 (DDL: %s)", pkCount, ddl)
 	}
 }
+
+// GetTables must not report SQLite internal tables such as sqlite_sequence,
+// which appears as soon as any table uses AUTOINCREMENT.
+func TestGetTablesExcludesInternal(t *testing.T) {
+	db, err := gorm.Open(Open("file:internal_tables?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	if err := db.Exec("CREATE TABLE `seq_table` (`id` integer PRIMARY KEY AUTOINCREMENT)").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec("INSERT INTO `seq_table` DEFAULT VALUES").Error; err != nil {
+		t.Fatal(err)
+	}
+
+	tables, err := db.Migrator().GetTables()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tb := range tables {
+		if strings.HasPrefix(tb, "sqlite_") {
+			t.Errorf("GetTables returned internal table %q", tb)
+		}
+	}
+	if len(tables) != 1 || tables[0] != "seq_table" {
+		t.Errorf("GetTables = %v, want [seq_table]", tables)
+	}
+}
+
+type checkedModel struct {
+	ID  int
+	Age int `gorm:"check:age_positive,age > 0"`
+}
+
+func (checkedModel) TableName() string { return "checked_models" }
+
+// HasConstraint must match the exact constraint name instead of a LIKE
+// substring, and DropColumn must fail for a column that is not in the DDL
+// instead of silently rebuilding an identical table.
+func TestConstraintAndColumnMatching(t *testing.T) {
+	db, err := gorm.Open(Open("file:constraint_matching?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	if err := db.AutoMigrate(&checkedModel{}); err != nil {
+		t.Fatal(err)
+	}
+	if !db.Migrator().HasConstraint(&checkedModel{}, "age_positive") {
+		t.Error("HasConstraint(age_positive) = false, want true")
+	}
+	if db.Migrator().HasConstraint(&checkedModel{}, "age_pos") {
+		t.Error("HasConstraint(age_pos) matched by prefix, want false")
+	}
+
+	// unquoted DDL: the column must still be dropped
+	if err := db.Exec("CREATE TABLE plain_cols (id integer, name text)").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Migrator().DropColumn(&plainColModel{}, "name"); err != nil {
+		t.Fatalf("DropColumn on unquoted DDL: %v", err)
+	}
+	if db.Migrator().HasColumn(&plainColModel{}, "name") {
+		t.Error("column still present after DropColumn on unquoted DDL")
+	}
+	// a missing column must be an error, not a silent no-op
+	if err := db.Migrator().DropColumn(&plainColModel{}, "missing"); err == nil {
+		t.Error("DropColumn(missing) = nil, want error")
+	}
+	// a missing table must be reported clearly
+	if err := db.Migrator().DropColumn(&noSuchTableModel{}, "col"); err == nil || !strings.Contains(err.Error(), "table not found") {
+		t.Errorf("DropColumn on a missing table = %v, want a table-not-found error", err)
+	}
+}
+
+type plainColModel struct {
+	ID   int
+	Name string
+}
+
+func (plainColModel) TableName() string { return "plain_cols" }
+
+type noSuchTableModel struct {
+	ID int
+}
+
+func (noSuchTableModel) TableName() string { return "no_such_table" }

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -400,3 +400,27 @@ type noSuchTableModel struct {
 }
 
 func (noSuchTableModel) TableName() string { return "no_such_table" }
+
+// HasConstraint reports a plain bool, so looking it up on a table that does not
+// exist must simply answer false and leave the caller's session usable.
+func TestHasConstraintMissingTable(t *testing.T) {
+	db, err := gorm.Open(Open("file:hasconstraint_missing?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	if db.Migrator().HasConstraint(&noSuchTableModel{}, "chk_x") {
+		t.Error("HasConstraint on a missing table = true, want false")
+	}
+	if db.Error != nil {
+		t.Errorf("session left with an error: %v", db.Error)
+	}
+	if err := db.Exec("CREATE TABLE hc_probe (id integer)").Error; err != nil {
+		t.Errorf("follow-up statement on the same session failed: %v", err)
+	}
+}

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -211,3 +211,58 @@ func openRecreateTestDB(t *testing.T, name string) *gorm.DB {
 	})
 	return db
 }
+
+type ConstraintParent struct {
+	ID int `gorm:"primaryKey"`
+}
+
+func (ConstraintParent) TableName() string { return "constraint_parents" }
+
+type ConstraintChild struct {
+	ID       int
+	ParentID int
+	Parent   ConstraintParent `gorm:"foreignKey:ParentID"`
+}
+
+func (ConstraintChild) TableName() string { return "constraint_children" }
+
+// CreateConstraint appends the constraint to the field list as a `CONSTRAINT ?
+// FOREIGN KEY ...` placeholder clause; getColumns must not mistake it for a
+// column, or the data copy fails with "no column named CONSTRAINT".
+func TestCreateConstraintPlaceholder(t *testing.T) {
+	db, err := gorm.Open(Open("file:constraint_placeholder?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	if err := db.AutoMigrate(&ConstraintParent{}); err != nil {
+		t.Fatal(err)
+	}
+	// existing table missing the foreign key declared in the model
+	if err := db.Exec("CREATE TABLE `constraint_children` (`id` integer, `parent_id` integer)").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec("INSERT INTO `constraint_children`(`id`,`parent_id`) VALUES (1, NULL)").Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.AutoMigrate(&ConstraintChild{}); err != nil {
+		t.Fatalf("AutoMigrate adding the missing foreign key: %v", err)
+	}
+
+	var n int
+	if err := db.Raw("SELECT count(*) FROM `constraint_children`").Scan(&n).Error; err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("rows after rebuild = %d, want 1", n)
+	}
+	if !db.Migrator().HasConstraint(&ConstraintChild{}, "fk_constraint_children_parent") {
+		t.Error("foreign key constraint missing after AutoMigrate")
+	}
+}

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -266,3 +266,39 @@ func TestCreateConstraintPlaceholder(t *testing.T) {
 		t.Error("foreign key constraint missing after AutoMigrate")
 	}
 }
+
+type compositeKeyModel struct {
+	A int    `gorm:"primaryKey;autoIncrement"`
+	B string `gorm:"primaryKey"`
+}
+
+func (compositeKeyModel) TableName() string { return "composite_key_models" }
+
+// A composite primary key that includes an auto-increment field must keep all
+// key columns. AUTOINCREMENT only applies to a single-column INTEGER PRIMARY
+// KEY, and emitting it made GORM skip the table-level PRIMARY KEY clause,
+// silently reducing the key to one column.
+func TestCompositePrimaryKeyAutoIncrement(t *testing.T) {
+	db, err := gorm.Open(Open("file:composite_pk?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	if err := db.AutoMigrate(&compositeKeyModel{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	var pkCount int
+	if err := db.Raw("SELECT count(*) FROM pragma_table_info('composite_key_models') WHERE pk > 0").Scan(&pkCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if pkCount != 2 {
+		var ddl string
+		_ = db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='composite_key_models'").Scan(&ddl).Error
+		t.Errorf("primary key column count = %d, want 2 (DDL: %s)", pkCount, ddl)
+	}
+}

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -163,6 +163,39 @@ func TestRecreateTableWithView(t *testing.T) {
 	}
 }
 
+// DropColumn and AlterColumn must accept a table-name string like the base
+// GORM migrator and the other dialects do; stmt.Schema is nil in that case
+// and used to cause a nil pointer dereference.
+func TestMigratorStringTableName(t *testing.T) {
+	db, err := gorm.Open(Open("file:migrator_string_value?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	// close the pool so the shared in-memory database is torn down and
+	// repeated runs (go test -count=N) start from a clean state
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	if err := db.Exec("CREATE TABLE `string_value_table` (`id` integer, `b` text)").Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Migrator().DropColumn("string_value_table", "b"); err != nil {
+		t.Errorf("DropColumn with a table-name string: %v", err)
+	}
+	if db.Migrator().HasColumn("string_value_table", "b") {
+		t.Error("column b still present after DropColumn")
+	}
+
+	// AlterColumn needs the model schema to build the new column type; a
+	// table-name string must produce a regular error, not a panic.
+	if err := db.Migrator().AlterColumn("string_value_table", "id"); err == nil {
+		t.Error("AlterColumn with a table-name string: expected an error, got nil")
+	}
+}
+
 func openRecreateTestDB(t *testing.T, name string) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(Open("file:"+name+"?mode=memory&cache=shared"), &gorm.Config{})

--- a/sqlite.go
+++ b/sqlite.go
@@ -223,7 +223,7 @@ func (dialector Dialector) dataTypeOf(field *schema.Field) string {
 	case schema.Bool:
 		return "numeric"
 	case schema.Int, schema.Uint:
-		if field.AutoIncrement {
+		if field.AutoIncrement && !isCompositePrimaryKey(field) {
 			// doesn't check `PrimaryKey`, to keep backward compatibility
 			// https://www.sqlite.org/autoinc.html
 			return "integer PRIMARY KEY AUTOINCREMENT"
@@ -317,4 +317,13 @@ func isIdentityKeyword(value string) bool {
 		}
 	}
 	return identity
+}
+
+// isCompositePrimaryKey reports whether field is part of a multi-column
+// primary key. AUTOINCREMENT only works on a single-column INTEGER PRIMARY
+// KEY; emitting it for a composite key would silently reduce the primary key
+// to that one column (GORM skips the table-level PRIMARY KEY clause when a
+// field type already contains PRIMARY KEY).
+func isCompositePrimaryKey(field *schema.Field) bool {
+	return field.PrimaryKey && field.Schema != nil && len(field.Schema.PrimaryFields) > 1
 }

--- a/sqlite.go
+++ b/sqlite.go
@@ -203,7 +203,8 @@ func (dialector Dialector) QuoteTo(writer clause.Writer, str string) {
 }
 
 func (dialector Dialector) Explain(sql string, vars ...interface{}) string {
-	return logger.ExplainSQL(sql, nil, `"`, vars...)
+	// single quotes: double quotes are identifier quoting in SQLite
+	return logger.ExplainSQL(sql, nil, `'`, vars...)
 }
 
 func (dialector Dialector) DataTypeOf(field *schema.Field) string {

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mattn/go-sqlite3"
@@ -128,5 +129,82 @@ func TestDialector(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestExplainQuotesStrings(t *testing.T) {
+	out := Dialector{}.Explain("SELECT * FROM t WHERE name = ?", "hello")
+	if !strings.Contains(out, "'hello'") {
+		t.Errorf("Explain must quote string literals with single quotes, got: %s", out)
+	}
+}
+
+type explainDefaultModel struct {
+	ID   int
+	Code string `gorm:"default:hello"`
+}
+
+func (explainDefaultModel) TableName() string { return "explain_defaults" }
+
+// GORM embeds string default values into the DDL via Dialector.Explain;
+// parseDDL must strip the single quotes (and double quotes from tables
+// created by older versions) so migrations stay idempotent.
+func TestDefaultValueRoundTrip(t *testing.T) {
+	db, err := gorm.Open(Open("file:explain_defaults?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	if err := db.AutoMigrate(&explainDefaultModel{}); err != nil {
+		t.Fatal(err)
+	}
+	cols, err := db.Migrator().ColumnTypes(&explainDefaultModel{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cols {
+		if c.Name() == "code" {
+			if dv, ok := c.DefaultValue(); !ok || dv != "hello" {
+				t.Errorf("DefaultValue = (%q,%v), want (hello,true)", dv, ok)
+			}
+		}
+	}
+	// second AutoMigrate must not rebuild the table
+	var before string
+	if err := db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='explain_defaults'").Scan(&before).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&explainDefaultModel{}); err != nil {
+		t.Fatal(err)
+	}
+	var after string
+	if err := db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='explain_defaults'").Scan(&after).Error; err != nil {
+		t.Fatal(err)
+	}
+	if before != after {
+		t.Errorf("DDL changed after second AutoMigrate:\n  before: %s\n  after:  %s", before, after)
+	}
+
+	// double quotes from tables created by older driver versions still parse
+	d, err := parseDDL("CREATE TABLE `legacy` (`code` text DEFAULT \"hi\")")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dv, ok := d.columns[0].DefaultValue(); !ok || dv != "hi" {
+		t.Errorf("legacy DefaultValue = (%q,%v), want (hi,true)", dv, ok)
+	}
+
+	// only one outer quote pair is stripped; inner quotes survive
+	d, err = parseDDL("CREATE TABLE `q` (`code` text DEFAULT '\"x\"')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dv, ok := d.columns[0].DefaultValue(); !ok || dv != `"x"` {
+		t.Errorf(`quoted DefaultValue = (%q,%v), want ("x",true)`, dv, ok)
 	}
 }


### PR DESCRIPTION
As requested, this consolidates the previously separate PRs #234, #241, #242, #243, #244 and #245 into this one. The other six are closed; nothing is dropped. Rebased onto current `master`, one commit per fix so each stays reviewable on its own.

---

### 1. `AlterColumn`/`DropColumn` panic when value is a table-name string (was #234)

The base GORM migrator accepts a table-name string as the `value` argument (`RunWithValue` sets `stmt.Table` and leaves `stmt.Schema` nil), and the other official dialects support this calling style. The sqlite driver dereferenced `stmt.Schema` unconditionally, so this panicked:

```go
db.Migrator().DropColumn("my_table", "my_column") // panic: invalid memory address
```

`DropColumn` works fine without a schema (the given column name is used as-is), so it now skips the field lookup, mirroring the guard `HasColumn` already has. `AlterColumn` cannot build the new column type without the schema and returns a regular error instead of panicking.

### 2. `?` placeholder in constraint clauses (was #241)

`CreateConstraint` appends the constraint to the DDL field list in the form produced by `constraint.Build()`: `` CONSTRAINT ? FOREIGN KEY ... ``. `constraintRegexp` required a backquoted name, so `getColumns` did not filter the clause out and extracted the literal `CONSTRAINT` as a column name; the rebuild's data copy then failed with

```
table x__temp has no column named CONSTRAINT
```

which breaks `AutoMigrate` whenever an existing table is missing a foreign key declared in the model. The regexp now accepts a quoted or unquoted name as well as the `?` placeholder.

### 3. `Explain` quotes string literals with double quotes (was #242 — fixes #197)

Double quotes are identifier quoting in SQLite, so SQL copied from the logs misparses the value as a column reference. Standard single-quoted string literals are used instead.

GORM also embeds string default values into `CREATE TABLE` through `Explain`, so the DDL parser now strips single quotes from parsed default values as well (double quotes are still stripped for tables created by older driver versions); without that, migrations would stop being idempotent. Only one matching outer pair is stripped, so inner quotes of values like `'"x"'` survive.

### 4. `rows.Close()` overwrites `ColumnTypes` errors (was #243)

The deferred `err = rows.Close()` unconditionally replaced the named return value, so any error from `rows.ColumnTypes()` or the merge loop was swallowed by the (almost always nil) `Close` result. The first error is kept instead.

### 5. Composite primary key reduced to its autoIncrement column (was #244 — related reports: #134, #126, glebarez/sqlite#148)

```go
type Model struct {
    A int    `gorm:"primaryKey;autoIncrement"`
    B string `gorm:"primaryKey"`
}
```

`AutoMigrate` succeeded but created ``(`a` integer PRIMARY KEY AUTOINCREMENT, `b` text)`` — B's primary-key declaration was silently dropped. `DataTypeOf` emitted `integer PRIMARY KEY AUTOINCREMENT` for any auto-increment int field, and GORM skips the table-level `PRIMARY KEY (a, b)` clause when the rendered field type already contains `PRIMARY KEY`.

AUTOINCREMENT only applies to a single-column INTEGER PRIMARY KEY in SQLite anyway, so the clause is dropped when the field is part of a multi-column key and the table-level `PRIMARY KEY (a, b)` takes effect. Single-key behavior — including `autoIncrement` without an explicit `primaryKey` tag — is unchanged, verified via `pragma_table_info`.

### 6. Parameterized types with precision like `decimal(10,2)` (was #245)

The type group of `columnRegexp` had no comma, so `decimal(10,2)` was truncated to `decimal(10` in `ColumnType()`, and the scale was lost. The type group now takes the whole parenthesized parameter list, and size parsing distinguishes a single length (`varchar(10)` → `Length`) from precision and scale (`decimal(10,2)` → `DecimalSize`/`Scale`), spaces after the comma included.

### 7. DDL matching and error reporting (this PR's original content)

- **`GetTables`**: exclude `sqlite_*` internal tables — `sqlite_sequence` appeared in the list as soon as any table used AUTOINCREMENT.
- **`HasConstraint`**: match the exact constraint name via the parsed DDL and `compileConstraintRegexp` instead of LIKE substrings, which matched prefixes (`age_pos` matched `age_positive`). Every quoting form the LIKE patterns handled — backquotes, double quotes, single quotes, brackets, unquoted — keeps working. It no longer returns errors from its `RunWithValue` callback either: the result is a plain `bool` and the caller discards the error, so a missing table simply answers `false`.
- **`DropColumn`**: report an error when the column is not present in the DDL; `removeColumn` returned `false` silently and the table was rebuilt unchanged, so callers saw success without any effect.
- **`removeColumn`**: match unquoted column names — the regexp required a quote or space *before* the name, so columns of hand-written DDL like `CREATE TABLE t (id integer, name text)` were never matched (same silent no-op as above).
- **`getRawDDL`**: report `table not found` instead of passing an empty string to `parseDDL`, which surfaced as a confusing `invalid DDL`.
- **`uniqueRegexp`**: recognize lowercase / no-space table-level `unique(...)` constraints; every other DDL regexp is already case-insensitive. Written to not mistake a column named `uniqueid` for a constraint (requires the parenthesized column list).

### 8. Identifier quoting and character set in the DDL regexps (review follow-up)

The parser only accepted `` ` ``, `"` and `'` quoting and ASCII `\w` names, while SQLite also allows `[name]` quoting and non-ASCII identifiers. Each regexp was one character class short in a different place, and the failure modes ranged from a confusing error to silent data loss:

| identifier | before | consequence |
| --- | --- | --- |
| constraint name | no `[name]`, no `-`, ASCII only | clause parsed as a column → `no column named CONSTRAINT` on rebuild |
| column name | no `[name]`, ASCII only | column missing from `ColumnTypes` **and from the rebuild's copy list — its data is lost** |
| table name | no `[name]` | `invalid DDL` from `HasConstraint`, `DropColumn`, `AlterColumn` |
| index name | no `[name]`, ASCII only | `ColumnTypes` parses table + index DDL together, so the whole call failed with `invalid DDL` |
| `UNIQUE` constraint name | ASCII only | column lost its unique flag |

`renameTable` needed the same treatment as `tableRegexp`: it rewrites the name inside the parsed head, and with the brackets left in place the rebuilt head became `` CREATE TABLE [ `t__temp` ] ``, which SQLite reads as a table whose name contains backquotes — the rebuild then failed with `no such table: t__temp`.

**Known limitation, deliberately not addressed:** a non-ASCII *table* name still fails. `renameTable` locates the name with `\b`, and Go's word boundary is ASCII-only, so it never matches next to a character like `用`. Fixing it means replacing `\b` with explicit delimiter matching and re-checking prefix collisions (`user` vs `users`) — a different kind of change from widening a character class, so it's left for its own PR.

---

### Tests

`go test ./...` and `go test -race ./...` pass. Added: `TestMigratorStringTableName`, `TestCreateConstraintPlaceholder`, `TestExplainQuotesStrings`, `TestDefaultValueRoundTrip`, `TestCompositePrimaryKeyAutoIncrement`, `TestParseDDL_TypePrecision`, `TestGetTablesExcludesInternal`, `TestConstraintAndColumnMatching`, `TestParseDDL_LowercaseUnique`, `TestConstraintNameQuoting`, `TestUniqueConstraintNameQuoting`, `TestRemoveColumnQuotingForms`, `TestHasConstraintMissingTable`, `TestParseDDL_ColumnIdentifiers`, `TestParseDDL_IndexIdentifiers`, `TestParseDDL_TableIdentifiers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
