### PR TITLE
fix: translate errors from the sqlite3 error type instead of JSON

### DIFF
--- a/error_translator.go
+++ b/error_translator.go
@@ -1,8 +1,6 @@
 package sqlite
 
 import (
-	"encoding/json"
-
 	"gorm.io/gorm"
 )
 
@@ -13,28 +11,14 @@ var errCodes = map[int]error{
 	787:  gorm.ErrForeignKeyViolated,
 }
 
+// ErrMessage was the intermediate shape the extended result code used to be
+// decoded into.
+//
+// Deprecated: Translate reads the extended result code from sqlite3.Error
+// directly and no longer decodes errors through JSON. This type is retained so
+// that code referring to it keeps compiling.
 type ErrMessage struct {
 	Code         int `json:"Code"`
 	ExtendedCode int `json:"ExtendedCode"`
 	SystemErrno  int `json:"SystemErrno"`
-}
-
-// Translate it will translate the error to native gorm errors.
-// We are not using go-sqlite3 error type intentionally here because it will need the CGO_ENABLED=1 and cross-C-compiler.
-func (dialector Dialector) Translate(err error) error {
-	parsedErr, marshalErr := json.Marshal(err)
-	if marshalErr != nil {
-		return err
-	}
-
-	var errMsg ErrMessage
-	unmarshalErr := json.Unmarshal(parsedErr, &errMsg)
-	if unmarshalErr != nil {
-		return err
-	}
-
-	if translatedErr, found := errCodes[errMsg.ExtendedCode]; found {
-		return translatedErr
-	}
-	return err
 }

--- a/error_translator_cgo.go
+++ b/error_translator_cgo.go
@@ -1,0 +1,39 @@
+//go:build cgo
+
+package sqlite
+
+import (
+	"errors"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+// Translate it will translate the error to native gorm errors.
+func (dialector Dialector) Translate(err error) error {
+	code, ok := extendedResultCode(err)
+	if !ok {
+		return err
+	}
+
+	if translatedErr, found := errCodes[code]; found {
+		return translatedErr
+	}
+	return err
+}
+
+// extendedResultCode reports the sqlite extended result code carried by err, if
+// any. The error chain is walked so that an error wrapped by a callback or a
+// plugin is still recognised.
+func extendedResultCode(err error) (int, bool) {
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		return int(sqliteErr.ExtendedCode), true
+	}
+
+	var sqliteErrPtr *sqlite3.Error
+	if errors.As(err, &sqliteErrPtr) && sqliteErrPtr != nil {
+		return int(sqliteErrPtr.ExtendedCode), true
+	}
+
+	return 0, false
+}

--- a/error_translator_nocgo.go
+++ b/error_translator_nocgo.go
@@ -1,0 +1,12 @@
+//go:build !cgo
+
+package sqlite
+
+// Translate returns err unchanged.
+//
+// sqlite3.Error is declared in a file that imports C, so it only exists when
+// cgo is enabled. Without cgo the driver cannot open a connection either, so no
+// sqlite error ever reaches this function and there is nothing to translate.
+func (dialector Dialector) Translate(err error) error {
+	return err
+}

--- a/error_translator_test.go
+++ b/error_translator_test.go
@@ -1,0 +1,143 @@
+//go:build cgo
+
+package sqlite
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func openTranslating(t *testing.T, dsn string) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(Open(dsn), &gorm.Config{
+		Logger:         logger.Default.LogMode(logger.Silent),
+		TranslateError: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	return db
+}
+
+func TestTranslateDuplicatedKeyOnUniqueColumn(t *testing.T) {
+	type Article struct {
+		ArticleNumber string `gorm:"unique"`
+	}
+
+	db := openTranslating(t, "file:translate_unique?mode=memory&cache=shared")
+	if err := db.AutoMigrate(&Article{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	if err := db.Create(&Article{ArticleNumber: "A00000XX"}).Error; err != nil {
+		t.Fatalf("expected the first create to succeed, got: %v", err)
+	}
+
+	err := db.Create(&Article{ArticleNumber: "A00000XX"}).Error
+	if !errors.Is(err, gorm.ErrDuplicatedKey) {
+		t.Errorf("expected gorm.ErrDuplicatedKey, got: %v", err)
+	}
+}
+
+func TestTranslateDuplicatedKeyOnPrimaryKey(t *testing.T) {
+	type Product struct {
+		Code string `gorm:"primaryKey"`
+	}
+
+	db := openTranslating(t, "file:translate_pk?mode=memory&cache=shared")
+	if err := db.AutoMigrate(&Product{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	if err := db.Create(&Product{Code: "P1"}).Error; err != nil {
+		t.Fatalf("expected the first create to succeed, got: %v", err)
+	}
+
+	err := db.Create(&Product{Code: "P1"}).Error
+	if !errors.Is(err, gorm.ErrDuplicatedKey) {
+		t.Errorf("expected gorm.ErrDuplicatedKey, got: %v", err)
+	}
+}
+
+func TestTranslateForeignKeyViolated(t *testing.T) {
+	db := openTranslating(t, "file:translate_fk?mode=memory&cache=shared&_foreign_keys=on")
+
+	if err := db.Exec("CREATE TABLE authors (id integer primary key)").Error; err != nil {
+		t.Fatalf("failed to create authors: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE books (id integer primary key, author_id integer REFERENCES authors(id))").Error; err != nil {
+		t.Fatalf("failed to create books: %v", err)
+	}
+
+	err := db.Exec("INSERT INTO books (author_id) VALUES (404)").Error
+	if !errors.Is(err, gorm.ErrForeignKeyViolated) {
+		t.Errorf("expected gorm.ErrForeignKeyViolated, got: %v", err)
+	}
+}
+
+func TestTranslateWrappedError(t *testing.T) {
+	dialector := Dialector{}
+	sqliteErr := sqlite3.Error{
+		Code:         sqlite3.ErrConstraint,
+		ExtendedCode: sqlite3.ErrConstraintUnique,
+	}
+
+	if err := dialector.Translate(sqliteErr); !errors.Is(err, gorm.ErrDuplicatedKey) {
+		t.Errorf("expected gorm.ErrDuplicatedKey, got: %v", err)
+	}
+
+	wrapped := fmt.Errorf("inserting article: %w", sqliteErr)
+	if err := dialector.Translate(wrapped); !errors.Is(err, gorm.ErrDuplicatedKey) {
+		t.Errorf("expected a wrapped error to be translated to gorm.ErrDuplicatedKey, got: %v", err)
+	}
+
+	if err := dialector.Translate(&sqliteErr); !errors.Is(err, gorm.ErrDuplicatedKey) {
+		t.Errorf("expected a pointer error to be translated to gorm.ErrDuplicatedKey, got: %v", err)
+	}
+}
+
+// errWithResultCodeFields looks like a sqlite error once it goes through JSON
+// but comes from somewhere else entirely.
+type errWithResultCodeFields struct {
+	Code         int
+	ExtendedCode int
+	SystemErrno  int
+}
+
+func (errWithResultCodeFields) Error() string { return "unrelated error from another library" }
+
+func TestTranslateLeavesForeignErrorTypesAlone(t *testing.T) {
+	dialector := Dialector{}
+
+	err := dialector.Translate(errWithResultCodeFields{Code: 19, ExtendedCode: 2067})
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		t.Error("expected an error from another package to be returned untouched")
+	}
+}
+
+func TestTranslateUnmappedCode(t *testing.T) {
+	dialector := Dialector{}
+	sqliteErr := sqlite3.Error{
+		Code:         sqlite3.ErrConstraint,
+		ExtendedCode: sqlite3.ErrConstraintNotNull,
+	}
+
+	if err := dialector.Translate(sqliteErr); !errors.Is(err, sqliteErr) {
+		t.Errorf("expected an unmapped code to be returned untouched, got: %v", err)
+	}
+}
+
+func TestTranslateNonSQLiteError(t *testing.T) {
+	dialector := Dialector{}
+	plain := errors.New("some other failure")
+
+	if err := dialector.Translate(plain); !errors.Is(err, plain) {
+		t.Errorf("expected a plain error to be returned untouched, got: %v", err)
+	}
+}


### PR DESCRIPTION
I maintain [glebarez/sqlite](https://github.com/glebarez/sqlite), the pure-Go fork of
this driver. I have been running a parity audit between the two, and I committed in
glebarez/sqlite#152 to sending anything backend-agnostic here first rather than letting
the fork drift. This is the first of those.

`Translate` currently round-trips the error through `encoding/json` and reads the
extended result code off the decoded object. That has two problems.

It matches on field names rather than on type. Any error carrying `Code`,
`ExtendedCode` and `SystemErrno` fields gets translated even when it comes from a
completely unrelated package. I added a test type whose message is "unrelated error
from another library" and today `Translate` turns it into `gorm.ErrDuplicatedKey`.

It also stops recognising a real sqlite error the moment something wraps it. `json.Marshal`
on a wrapped error produces `{}`, so the extended code reads back as `0`. Any callback,
hook or plugin that adds context to the driver error before it reaches `AddError` loses
translation silently.

This reads the extended result code from `sqlite3.Error` through `errors.As`, so the
whole error chain is searched and only real sqlite errors match. Both `sqlite3.Error`
and `*sqlite3.Error` are probed, so the pointer case that worked before keeps working.

About the comment saying the go-sqlite3 error type is avoided because it needs cgo: I
checked, and that reason is correct. `sqlite3.Error` is declared in a file that imports
C, so it does not exist under `CGO_ENABLED=0`, and a plain type switch would break that
build. So `Translate` is split by build tag. The non-cgo build returns the error
untouched, which is the right answer there: without cgo the driver cannot open a
connection at all, so no sqlite error ever reaches the function. That also removes the
false positives on that build, where the JSON heuristic could only ever misfire.

`ErrMessage` is exported, so I kept it and marked it deprecated rather than deleting it.

One compatibility note. If someone points this Dialector at a pure-Go sqlite driver via
`DriverName` and builds with `CGO_ENABLED=0`, translation becomes a no-op. That is not a
regression: `modernc.org/sqlite`'s error type has unexported fields, so `json.Marshal`
already produced `{}` and the old code did not translate it either.

There was no test for `Translate` before this, so all seven tests are new. Two of them
fail against the old implementation and pass against the new one. The other five pass
against both, which is what shows existing behaviour is unchanged.

`go test ./...` goes from 70 passing to 77, no failures. `gofmt`, `go vet`,
`CGO_ENABLED=0 go build ./...` and `CGO_ENABLED=0 go vet ./...` are all clean.